### PR TITLE
Cleanup and clippy fixes

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,8 @@
 #[allow(unused)]
 #[repr(u8)]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Error {
-    NoError = 0,
+    None = 0,
     BadDataLen = 0xC0,
     BadDataChecksum = 0xC1,
     BadBlocksize = 0xC2,
@@ -10,7 +10,7 @@ pub enum Error {
     FailedSpiOp = 0xC4,
     FailedSpiUnlock = 0xC5,
     NotInFlashMode = 0xC6,
-    InflateError = 0xC7,
+    Inflate = 0xC7,
     NotEnoughData = 0xC8,
     TooMuchData = 0xC9,
     CmdNotImplemented = 0xFF,
@@ -23,7 +23,7 @@ pub enum Error {
 }
 
 #[allow(unused)]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Code {
     FlashBegin = 0x02,
     FlashData = 0x03,
@@ -109,7 +109,7 @@ pub struct ReadReg {
 }
 
 // Possibly move to other module
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 #[repr(C, packed(1))]
 pub struct SpiParams {
     pub id: u32,
@@ -153,7 +153,7 @@ pub struct EraseRegion {
 }
 
 // Possibly move to other module
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[repr(C, packed(1))]
 pub struct ReadFlashParams {
     pub address: u32,
@@ -207,7 +207,7 @@ impl<'a> Response<'a> {
             size: 2,
             value: 0,
             status: Status::Success,
-            error: Error::NoError,
+            error: Error::None,
             data: &[],
         }
     }

--- a/src/miniz_types.rs
+++ b/src/miniz_types.rs
@@ -17,21 +17,19 @@ pub enum TinflStatus {
     Failed = -1,
     Done = 0,
     NeedsMoreInput = 1,
-    HasMoreOutput = 2
+    HasMoreOutput = 2,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C, packed(1))]
-struct tinfl_huff_table
-{
+struct tinfl_huff_table {
     code_size: [u8; TINFL_MAX_HUFF_SYMBOLS_0],
-    look_up: [u16;TINFL_FAST_LOOKUP_SIZE],
-    tree: [u16; TINFL_MAX_HUFF_SYMBOLS_0 * 2]
+    look_up: [u16; TINFL_FAST_LOOKUP_SIZE],
+    tree: [u16; TINFL_MAX_HUFF_SYMBOLS_0 * 2],
 }
 
 #[repr(C, packed(1))]
-pub struct tinfl_decompressor
-{
+pub struct tinfl_decompressor {
     pub state: u32,
     num_bits: u32,
     zhdr0: u32,
@@ -48,15 +46,15 @@ pub struct tinfl_decompressor
     dist_from_out_buf_start: u32,
     tables: [tinfl_huff_table; TINFL_MAX_HUFF_TABLES],
     raw_header: [u8; 4],
-    len_codes: [u8; TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137]
+    len_codes: [u8; TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137],
 }
 
 impl Default for tinfl_huff_table {
     fn default() -> Self {
         tinfl_huff_table {
             code_size: [0; TINFL_MAX_HUFF_SYMBOLS_0],
-            look_up: [0;TINFL_FAST_LOOKUP_SIZE],
-            tree: [0; TINFL_MAX_HUFF_SYMBOLS_0 * 2]
+            look_up: [0; TINFL_FAST_LOOKUP_SIZE],
+            tree: [0; TINFL_MAX_HUFF_SYMBOLS_0 * 2],
         }
     }
 }
@@ -80,7 +78,7 @@ impl Default for tinfl_decompressor {
             dist_from_out_buf_start: 0,
             tables: [Default::default(); TINFL_MAX_HUFF_TABLES],
             raw_header: [0; 4],
-            len_codes: [0; TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137]
+            len_codes: [0; TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137],
         }
     }
 }
@@ -88,12 +86,12 @@ impl Default for tinfl_decompressor {
 #[allow(unused)]
 extern "C" {
     pub fn tinfl_decompress(
-        r: *mut tinfl_decompressor, 
-        in_buf: *const u8, 
-        in_buf_size: *mut usize, 
-        out_buf_start: *mut u8, 
-        out_buf_next: *mut u8, 
-        out_buf_size: *mut usize, 
-        flags: u32
+        r: *mut tinfl_decompressor,
+        in_buf: *const u8,
+        in_buf_size: *mut usize,
+        out_buf_start: *mut u8,
+        out_buf_next: *mut u8,
+        out_buf_size: *mut usize,
+        flags: u32,
     ) -> TinflStatus;
 }

--- a/src/miniz_types.rs
+++ b/src/miniz_types.rs
@@ -9,7 +9,7 @@ pub const TINFL_FLAG_HAS_MORE_INPUT: u32 = 2;
 
 #[allow(unused)]
 #[repr(C)]
-#[derive(PartialEq, PartialOrd)]
+#[derive(PartialEq, Eq, PartialOrd)]
 pub enum TinflStatus {
     FailedCannotMakeProgress = -4,
     BadParam = -3,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,19 +1,11 @@
-#[cfg_attr(test, mockall_double::double)]
-use crate::targets::esp32c3 as target;
-
-pub trait InputIO {
-    fn recv(&mut self) -> u8;
-    fn send(&mut self, data: &[u8]);
-}
-
-type FlashFunc = fn(addr: u32, data: *const u8, len: u32) -> Result<(), Error>;
-
 use core::{cmp::min, mem::size_of, slice};
 
 use md5::{Digest, Md5};
 use slip::*;
 use target::*;
 
+#[cfg_attr(test, mockall_double::double)]
+use crate::targets::esp32c3 as target;
 use crate::{
     commands,
     commands::{Code, Code::*, Error, Error::*, Response, RESPONSE_SIZE},
@@ -26,6 +18,14 @@ const CMD_BASE_SIZE: usize = size_of::<commands::Base>();
 
 const FLASH_SECTOR_SIZE: u32 = 4096;
 const MAX_WRITE_BLOCK: u32 = 0x4000;
+
+type FlashFunc = fn(addr: u32, data: *const u8, len: u32) -> Result<(), Error>;
+
+pub trait InputIO {
+    fn recv(&mut self) -> u8;
+    fn send(&mut self, data: &[u8]);
+}
+
 pub struct Stub<'a> {
     io: &'a mut (dyn InputIO + 'a),
     end_addr: u32,
@@ -38,8 +38,7 @@ pub struct Stub<'a> {
     in_flash_mode: bool,
 }
 
-fn slice_to_struct<T: Sized + Copy>(slice: &[u8]) -> Result<T, Error>
-{
+fn slice_to_struct<T: Sized + Copy>(slice: &[u8]) -> Result<T, Error> {
     if slice.len() < size_of::<T>() {
         return Err(Error::BadDataLen);
     }
@@ -48,11 +47,11 @@ fn slice_to_struct<T: Sized + Copy>(slice: &[u8]) -> Result<T, Error>
 }
 
 pub unsafe fn to_slice_u8<T: Sized>(p: &T) -> &[u8] {
-    slice::from_raw_parts( (p as *const T) as *const u8, size_of::<T>(), )
+    slice::from_raw_parts((p as *const T) as *const u8, size_of::<T>())
 }
 
 fn u32_from_slice(slice: &[u8], index: usize) -> u32 {
-    u32::from_le_bytes(slice[index..index+4].try_into().unwrap())
+    u32::from_le_bytes(slice[index..index + 4].try_into().unwrap())
 }
 
 fn calculate_md5(mut address: u32, mut size: u32) -> Result<[u8; 16], Error> {
@@ -72,9 +71,8 @@ fn calculate_md5(mut address: u32, mut size: u32) -> Result<[u8; 16], Error> {
 }
 
 impl<'a> Stub<'a> {
-
     pub fn new(input_io: &'a mut dyn InputIO) -> Self {
-        Stub { 
+        Stub {
             io: input_io,
             write_addr: 0,
             end_addr: 0,
@@ -88,7 +86,7 @@ impl<'a> Stub<'a> {
     }
 
     fn send_response(&mut self, resp: &Response) {
-        let resp_slice = unsafe{ to_slice_u8(resp) };
+        let resp_slice = unsafe { to_slice_u8(resp) };
         write_delimiter(self.io);
         write_raw(self.io, &resp_slice[..RESPONSE_SIZE]);
         write_raw(self.io, resp.data);
@@ -96,19 +94,19 @@ impl<'a> Stub<'a> {
     }
 
     fn send_response_with_data(&mut self, resp: &Response, data: &[u8]) {
-        let resp_slice = unsafe{ to_slice_u8(resp) };
+        let resp_slice = unsafe { to_slice_u8(resp) };
         write_delimiter(self.io);
-        write_raw(self.io, &resp_slice[..RESPONSE_SIZE-2]);
+        write_raw(self.io, &resp_slice[..RESPONSE_SIZE - 2]);
         write_raw(self.io, data);
-        write_raw(self.io, &resp_slice[RESPONSE_SIZE-2..RESPONSE_SIZE]);
+        write_raw(self.io, &resp_slice[RESPONSE_SIZE - 2..RESPONSE_SIZE]);
         write_delimiter(self.io);
     }
 
     fn send_md5_response(&mut self, resp: &Response, md5: &[u8]) {
         self.send_response_with_data(resp, md5)
     }
-    
-    fn send_security_info_response(&mut self, resp: &Response, info: &[u8])  {
+
+    fn send_security_info_response(&mut self, resp: &Response, info: &[u8]) {
         self.send_response_with_data(resp, info)
     }
 
@@ -118,15 +116,14 @@ impl<'a> Stub<'a> {
     }
 
     fn process_begin(&mut self, cmd: &commands::Begin) -> Result<(), Error> {
-
         // Align erase addreess to sector boundady.
-        self.erase_addr =  cmd.offset & FLASH_SECTOR_MASK;
+        self.erase_addr = cmd.offset & FLASH_SECTOR_MASK;
         self.write_addr = cmd.offset;
         self.end_addr = cmd.offset + cmd.total_size;
         self.remaining_compressed = (cmd.packt_count * cmd.packet_size) as usize;
         self.remaining = cmd.total_size;
         self.decompressor.state = 0;
-        
+
         match cmd.base.code {
             FlashBegin | FlashDeflBegin => {
                 if cmd.packet_size > MAX_WRITE_BLOCK {
@@ -136,30 +133,29 @@ impl<'a> Stub<'a> {
                 self.in_flash_mode = true;
                 unlock_flash()?;
             }
-            _ => () // Do nothing for MemBegin
+            _ => (), // Do nothing for MemBegin
         }
 
         Ok(())
     }
 
     fn process_end(&mut self, cmd: &commands::End, response: &Response) -> Result<(), Error> {
-
         if cmd.base.code == MemEnd {
             let addr = self.erase_addr as *const u32;
             let length = self.end_addr - self.erase_addr;
             let slice = unsafe { slice::from_raw_parts(addr, length as usize) };
             let mut memory: [u32; 32] = [0; 32];
             memory.copy_from_slice(&slice);
-            return match self.remaining { 
+            return match self.remaining {
                 0 => Ok(()),
-                _ => Err(NotEnoughData) 
-            }
+                _ => Err(NotEnoughData),
+            };
         } else if !self.in_flash_mode {
             return Err(NotInFlashMode);
         } else if self.remaining > 0 {
             return Err(NotEnoughData);
         }
-        
+
         self.in_flash_mode = false;
 
         if cmd.run_user_code == 1 {
@@ -179,28 +175,28 @@ impl<'a> Stub<'a> {
         } else if data_len % 4 != 0 {
             return Err(BadDataLen);
         }
-        
-        let (_, data_u32, _) = unsafe{ data.align_to::<u32>() };
-        
+
+        let (_, data_u32, _) = unsafe { data.align_to::<u32>() };
+
         for word in data_u32 {
             let memory = self.write_addr as *mut u32;
-            unsafe{ *memory = *word }; 
+            unsafe { *memory = *word };
             self.write_addr += 4;
         }
-        
+
         Ok(())
     }
 
     fn flash(&mut self, flash_write: FlashFunc, data: &[u8]) {
-
         let mut address = self.write_addr;
         let mut remaining = min(self.remaining, data.len() as u32);
         let mut written = 0;
 
         // Erase flash
         while self.erase_addr < self.write_addr + remaining {
-            if self.end_addr >= self.erase_addr + FLASH_BLOCK_SIZE && 
-            self.erase_addr % FLASH_BLOCK_SIZE == 0 {
+            if self.end_addr >= self.erase_addr + FLASH_BLOCK_SIZE
+                && self.erase_addr % FLASH_BLOCK_SIZE == 0
+            {
                 flash_erase_block(self.erase_addr);
                 self.erase_addr += FLASH_BLOCK_SIZE;
             } else {
@@ -208,7 +204,7 @@ impl<'a> Stub<'a> {
                 self.erase_addr += FLASH_SECTOR_SIZE;
             }
         }
-        
+
         // Write flash
         while remaining > 0 {
             let to_write = min(FLASH_SECTOR_SIZE, remaining);
@@ -229,27 +225,27 @@ impl<'a> Stub<'a> {
 
     fn flash_defl_data(&mut self, data: &[u8]) {
         use crate::miniz_types::TinflStatus::*;
-        
-        const OUT_BUFFER_SIZE: usize = 0x8000; //32768;
+
+        const OUT_BUFFER_SIZE: usize = 0x8000; // 32768;
         static mut DECOMPRESS_BUF: [u8; OUT_BUFFER_SIZE] = [0; OUT_BUFFER_SIZE];
         static mut DECOMPRESS_INDEX: usize = 0;
-        
-        let mut out_index = unsafe{ DECOMPRESS_INDEX };
-        let out_buf = unsafe{ &mut DECOMPRESS_BUF };
+
+        let mut out_index = unsafe { DECOMPRESS_INDEX };
+        let out_buf = unsafe { &mut DECOMPRESS_BUF };
         let mut in_index = 0;
         let mut length = data.len();
         let mut status = NeedsMoreInput;
         let mut flags = TINFL_FLAG_PARSE_ZLIB_HEADER;
-        
+
         while length > 0 && self.remaining > 0 && status != Done {
             let mut in_bytes = length;
             let mut out_bytes = out_buf.len() - out_index;
             let next_out: *mut u8 = out_buf[out_index..].as_mut_ptr();
-            
+
             if self.remaining_compressed > length {
                 flags |= TINFL_FLAG_HAS_MORE_INPUT;
             }
-            
+
             status = target::decompress(
                 &mut self.decompressor,
                 data[in_index..].as_ptr(),
@@ -257,21 +253,22 @@ impl<'a> Stub<'a> {
                 out_buf.as_mut_ptr(),
                 next_out,
                 &mut out_bytes,
-                flags);
-                
-                self.remaining_compressed -= in_bytes;
-                length -= in_bytes;
-                in_index += in_bytes;
-                out_index += out_bytes;
-                
-                if status == Done || out_index == OUT_BUFFER_SIZE {
-                    self.flash_data(&out_buf[..out_index]);
-                    out_index = 0;
-                }
+                flags,
+            );
+
+            self.remaining_compressed -= in_bytes;
+            length -= in_bytes;
+            in_index += in_bytes;
+            out_index += out_bytes;
+
+            if status == Done || out_index == OUT_BUFFER_SIZE {
+                self.flash_data(&out_buf[..out_index]);
+                out_index = 0;
             }
-            
-        unsafe{ DECOMPRESS_INDEX = out_index }; 
-        
+        }
+
+        unsafe { DECOMPRESS_INDEX = out_index };
+
         // error won't get sent back until next block is sent
         if status < Done {
             self.last_error = Some(InflateError);
@@ -288,7 +285,12 @@ impl<'a> Stub<'a> {
         write_encrypted_disable();
     }
 
-    fn process_data(&mut self, cmd: &commands::Data, data: &[u8], response: &Response) -> Result<(), Error> {
+    fn process_data(
+        &mut self,
+        cmd: &commands::Data,
+        data: &[u8],
+        response: &Response,
+    ) -> Result<(), Error> {
         let checksum: u8 = data.iter().fold(0xEF, |acc, x| acc ^ x);
 
         if !self.in_flash_mode {
@@ -298,17 +300,17 @@ impl<'a> Stub<'a> {
         } else if cmd.base.checksum != checksum as u32 {
             return Err(BadDataChecksum);
         }
-        
+
         self.send_response(&response);
-        
+
         match cmd.base.code {
             FlashEncryptedData => self.flash_encrypt_data(data),
             FlashDeflData => self.flash_defl_data(data),
             FlashData => self.flash_data(data),
             MemData => self.write_ram(data)?,
-            _ => ()
+            _ => (),
         }
-        
+
         Ok(())
     }
 
@@ -344,10 +346,11 @@ impl<'a> Stub<'a> {
 
     #[allow(unreachable_patterns)]
     fn execute_command(
-        &mut self, payload: &[u8], 
-        code: Code, 
-        response: &mut Response) -> Result<bool, Error> {
-        
+        &mut self,
+        payload: &[u8],
+        code: Code,
+        response: &mut Response,
+    ) -> Result<bool, Error> {
         let mut response_sent = false;
 
         dprintln!("process command: {:?}", code);
@@ -357,7 +360,7 @@ impl<'a> Stub<'a> {
                 for _ in 1..=7 {
                     self.send_response(&response);
                 }
-            },
+            }
             ReadReg => {
                 let address = u32_from_slice(payload, CMD_BASE_SIZE);
                 response.value(read_register(address));
@@ -397,14 +400,12 @@ impl<'a> Stub<'a> {
             ChangeBaudrate => {
                 let baud: commands::ChangeBaudrate = slice_to_struct(payload)?;
                 self.send_response(&response);
-                delay_us(10000); // Wait for response to be transfered 
+                delay_us(10000); // Wait for response to be transfered
                 change_baudrate(baud.old, baud.new);
                 self.send_greeting();
                 response_sent = true;
             }
-            EraseFlash => {
-                erase_flash()?
-            }
+            EraseFlash => erase_flash()?,
             EraseRegion => {
                 let reg: commands::EraseRegion = slice_to_struct(payload)?;
                 erase_region(reg.address, reg.size)?;
@@ -432,16 +433,15 @@ impl<'a> Stub<'a> {
     }
 
     pub fn process_command(&mut self, payload: &[u8]) {
-        
         let command: commands::Base = slice_to_struct(&payload).unwrap();
         let mut response = Response::new(command.code);
 
         match self.execute_command(payload, command.code, &mut response) {
-            Ok(response_sent) =>  match response_sent {
+            Ok(response_sent) => match response_sent {
                 true => return,
                 false => (),
-            }
-            Err(err) => response.error(err)
+            },
+            Err(err) => response.error(err),
         }
 
         self.send_response(&response);
@@ -459,14 +459,13 @@ mod slip {
     pub const ESCAPE: u8 = 0xDB;
     pub const DELIMITER_END: u8 = 0xDC;
     pub const ESCAPE_END: u8 = 0xDD;
-    pub const DELIMITER_REPLACEMNT: &[u8;2] = &[0xDB, 0xDC];
-    pub const ESCAPE_REPLACEMNT: &[u8;2] = &[0xDB, 0xDD];
+    pub const DELIMITER_REPLACEMNT: &[u8; 2] = &[0xDB, 0xDC];
+    pub const ESCAPE_REPLACEMNT: &[u8; 2] = &[0xDB, 0xDD];
 
     pub fn read_packet<'c, 'd>(io: &'c mut dyn InputIO, packet: &'d mut [u8]) -> &'d [u8] {
-        
-        while io.recv() != 0xC0 { }
+        while io.recv() != 0xC0 {}
 
-        // Replase: 0xDB 0xDC -> 0xC0 and 0xDB 0xDD -> 0xDB   
+        // Replase: 0xDB 0xDC -> 0xC0 and 0xDB 0xDD -> 0xDB
         let mut i = 0;
         loop {
             match io.recv() {
@@ -474,8 +473,7 @@ mod slip {
                     DELIMITER_END => packet[i] = DELIMITER,
                     ESCAPE_END => packet[i] = ESCAPE,
                     _ => continue, // Framing error, continue processing
-                        
-                }
+                },
                 DELIMITER => break,
                 other => packet[i] = other,
             };
@@ -483,13 +481,13 @@ mod slip {
         }
 
         &packet[..i]
-    } 
+    }
 
     pub fn write_raw(io: &mut dyn InputIO, data: &[u8]) {
         for byte in data {
             match byte {
-                &DELIMITER  => io.send(DELIMITER_REPLACEMNT),
-                &ESCAPE  => io.send(ESCAPE_REPLACEMNT),
+                &DELIMITER => io.send(DELIMITER_REPLACEMNT),
+                &ESCAPE => io.send(ESCAPE_REPLACEMNT),
                 other => io.send(&[*other]),
             }
         }
@@ -500,7 +498,7 @@ mod slip {
         write_raw(io, data);
         write_delimiter(io);
     }
-    
+
     pub fn write_delimiter(io: &mut dyn InputIO) {
         io.send(&[0xC0]);
     }
@@ -508,28 +506,33 @@ mod slip {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    // use super::stub::Error::*;
-    use super::slip::{read_packet, write_raw};
+    use std::{collections::VecDeque, vec::Vec};
+
     use assert2::{assert, let_assert};
-    // use matches::assert_matches;
-    use std::collections::VecDeque;
-    use std::vec::Vec;
-    use crate::commands::*;
     use mockall::predicate;
 
+    use super::{
+        slip::{read_packet, write_raw},
+        *,
+    };
+    use crate::commands::*;
+
     struct MockIO {
-        data: VecDeque<u8>
+        data: VecDeque<u8>,
     }
 
     impl MockIO {
         fn from_slice(bytes: &[u8]) -> Self {
             let bytes_vec = Vec::from(bytes);
-            MockIO { data: VecDeque::from(bytes_vec) }
+            MockIO {
+                data: VecDeque::from(bytes_vec),
+            }
         }
 
         fn new() -> Self {
-            MockIO { data: VecDeque::new() }
+            MockIO {
+                data: VecDeque::new(),
+            }
         }
 
         fn fill(&mut self, bytes: &[u8]) {
@@ -550,12 +553,11 @@ mod tests {
         fn read(&mut self) -> Result<u8, ErrorIO> {
             match self.data.pop_front() {
                 Some(top) => Ok(top),
-                None => Err(Incomplete)
+                None => Err(Incomplete),
             }
         }
 
-        fn write(&mut self, bytes: &[u8]) -> Result<(), ErrorIO>
-        {
+        fn write(&mut self, bytes: &[u8]) -> Result<(), ErrorIO> {
             self.data.extend(bytes);
             Ok(())
         }
@@ -565,38 +567,38 @@ mod tests {
     fn test_read_packet() {
         let mut io = MockIO::new();
         let mut buffer: Buffer = heapless::Vec::new();
-        
-        // Returns Incomplete when packet enclosed by 0xC0 was not found 
+
+        // Returns Incomplete when packet enclosed by 0xC0 was not found
         io.fill(&[0xC0, 0xAA, 0x22]);
-        assert!( read_packet(&mut io, &mut buffer) == Err(Incomplete));
-        
+        assert!(read_packet(&mut io, &mut buffer) == Err(Incomplete));
+
         // Returns Incomplete when no 0xC0 is found
         io.fill(&[0x00, 0xAA, 0x22]);
-        assert!( read_packet(&mut io, &mut buffer) == Err(Incomplete));
+        assert!(read_packet(&mut io, &mut buffer) == Err(Incomplete));
 
         // Can find packet by 0xC0
         io.fill(&[0xC0, 0x11, 0x22, 0xC0]);
-        assert!( read_packet(&mut io, &mut buffer) == Ok(()));
-        assert!( buffer.as_slice() == &[0x11, 0x22] );
-        
+        assert!(read_packet(&mut io, &mut buffer) == Ok(()));
+        assert!(buffer.as_slice() == &[0x11, 0x22]);
+
         // Can find packet by 0xC0
         io.fill(&[0xC0, 0x11, 0x22, 0xC0]);
-        assert!( read_packet(&mut io, &mut buffer) == Ok(()));
-        assert!( buffer.as_slice() == &[0x11, 0x22] );
+        assert!(read_packet(&mut io, &mut buffer) == Ok(()));
+        assert!(buffer.as_slice() == &[0x11, 0x22]);
 
         // Can convert 0xDB 0xDC -> 0xC0
         io.fill(&[0xC0, 0x11, 0xDB, 0xDC, 0x22, 0xC0]);
-        assert!( read_packet(&mut io, &mut buffer) == Ok(()));
-        assert!( buffer.as_slice() == &[0x11, 0xC0, 0x22] );
+        assert!(read_packet(&mut io, &mut buffer) == Ok(()));
+        assert!(buffer.as_slice() == &[0x11, 0xC0, 0x22]);
 
         // Can convert 0xDB 0xDD -> 0xDB
         io.fill(&[0xC0, 0x11, 0xDB, 0xDD, 0x22, 0xC0]);
-        assert!( read_packet(&mut io, &mut buffer) == Ok(()));
-        assert!( buffer.as_slice() == &[0x11, 0xDB, 0x22] );
+        assert!(read_packet(&mut io, &mut buffer) == Ok(()));
+        assert!(buffer.as_slice() == &[0x11, 0xDB, 0x22]);
 
         // Returns InvalidResponse after invalid byte pair
         io.fill(&[0xC0, 0x11, 0xDB, 0x22, 0xDB, 0x33, 0x44, 0xC0]);
-        assert!( read_packet(&mut io, &mut buffer) == Err(InvalidResponse));
+        assert!(read_packet(&mut io, &mut buffer) == Err(InvalidResponse));
     }
 
     #[test]
@@ -604,13 +606,13 @@ mod tests {
         let mut io = MockIO::new();
 
         // 0xC0 is replaced with 0xDB 0xDC
-        assert!( write_raw(&mut io, &[1, 0xC0, 3]) == Ok(()));
-        assert!( io.written() == &[1, 0xDB, 0xDC, 3] );
+        assert!(write_raw(&mut io, &[1, 0xC0, 3]) == Ok(()));
+        assert!(io.written() == &[1, 0xDB, 0xDC, 3]);
         io.clear();
 
         // 0xDB is replaced with 0xDB 0xDD
-        assert!( write_raw(&mut io, &[1, 0xDB, 3]) == Ok(()));
-        assert!( io.written() == &[1, 0xDB, 0xDD, 3] );
+        assert!(write_raw(&mut io, &[1, 0xDB, 3]) == Ok(()));
+        assert!(io.written() == &[1, 0xDB, 0xDD, 3]);
         io.clear();
     }
 
@@ -619,92 +621,185 @@ mod tests {
         let mut dummy = CommandCode::Sync;
         // Check FlashBegin command
         let mut io = MockIO::from_slice(&[
-            0xC0, 
-            0,          // direction
+            0xC0,
+            0, // direction
             CommandCode::FlashBegin as u8,
-            16, 0,      // size
-            1, 0, 0, 0, // checksum
-            2, 0, 0, 0, // erase_addr
-            3, 0, 0, 0, // packt_count
-            4, 0, 0, 0, // packet_size
-            5, 0, 0, 0, // offset
-            0xC0]);
+            16,
+            0, // size
+            1,
+            0,
+            0,
+            0, // checksum
+            2,
+            0,
+            0,
+            0, // erase_addr
+            3,
+            0,
+            0,
+            0, // packt_count
+            4,
+            0,
+            0,
+            0, // packet_size
+            5,
+            0,
+            0,
+            0, // offset
+            0xC0,
+        ]);
         let mut stub = Stub::new(&mut io);
-        let_assert!( Ok(Command::Begin(cmd)) = stub.wait_for_command(&mut dummy) );
-        assert!( {cmd.base.direction == 0} );
-        assert!( {cmd.base.code == CommandCode::FlashBegin} );
-        assert!( {cmd.base.size == 16} );
-        assert!( {cmd.base.checksum == 1} );
-        assert!( {cmd.total_size == 2} );
-        assert!( {cmd.packt_count == 3} );
-        assert!( {cmd.packet_size == 4} );
-        assert!( {cmd.offset == 5} );
+        let_assert!(Ok(Command::Begin(cmd)) = stub.wait_for_command(&mut dummy));
+        assert!({ cmd.base.direction == 0 });
+        assert!({ cmd.base.code == CommandCode::FlashBegin });
+        assert!({ cmd.base.size == 16 });
+        assert!({ cmd.base.checksum == 1 });
+        assert!({ cmd.total_size == 2 });
+        assert!({ cmd.packt_count == 3 });
+        assert!({ cmd.packet_size == 4 });
+        assert!({ cmd.offset == 5 });
 
         // Check FlashData command
         let mut io = MockIO::from_slice(&[
-            0xC0, 
-            0,          // direction
+            0xC0,
+            0, // direction
             CommandCode::FlashData as u8,
-            20, 0,      // size
-            1, 0, 0, 0, // checksum
-            4, 0, 0, 0, // size
-            3, 0, 0, 0, // sequence_num
-            0, 0, 0, 0, // reserved 1
-            0, 0, 0, 0, // reserved 1
-            9, 8, 7, 6, // payload
-            0xC0]);
+            20,
+            0, // size
+            1,
+            0,
+            0,
+            0, // checksum
+            4,
+            0,
+            0,
+            0, // size
+            3,
+            0,
+            0,
+            0, // sequence_num
+            0,
+            0,
+            0,
+            0, // reserved 1
+            0,
+            0,
+            0,
+            0, // reserved 1
+            9,
+            8,
+            7,
+            6, // payload
+            0xC0,
+        ]);
         let mut stub = Stub::new(&mut io);
-        let_assert!( Ok(Command::Data(cmd, data)) = stub.wait_for_command(&mut dummy) );
-        assert!( {cmd.base.code == CommandCode::FlashData} );
-        assert!( {cmd.base.size == 20} );
-        assert!( {cmd.base.checksum == 1} );
-        assert!( {cmd.size == 4} );
-        assert!( {cmd.sequence_num == 3} );
-        assert!( {cmd.reserved[0] == 0} );
-        assert!( {cmd.reserved[1] == 0} );
-        assert!( data == &[9, 8, 7, 6] );
+        let_assert!(Ok(Command::Data(cmd, data)) = stub.wait_for_command(&mut dummy));
+        assert!({ cmd.base.code == CommandCode::FlashData });
+        assert!({ cmd.base.size == 20 });
+        assert!({ cmd.base.checksum == 1 });
+        assert!({ cmd.size == 4 });
+        assert!({ cmd.sequence_num == 3 });
+        assert!({ cmd.reserved[0] == 0 });
+        assert!({ cmd.reserved[1] == 0 });
+        assert!(data == &[9, 8, 7, 6]);
 
         // Check Sync command
         let mut io = MockIO::from_slice(&[
-            0xC0, 
-            0,          // direction
+            0xC0,
+            0, // direction
             CommandCode::Sync as u8,
-            36, 0,      // size
-            1, 0, 0, 0, // checksum
-            0x7, 0x7, 0x12, 0x20,
-            0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
-            0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
-            0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
-            0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
-            0xC0]);
+            36,
+            0, // size
+            1,
+            0,
+            0,
+            0, // checksum
+            0x7,
+            0x7,
+            0x12,
+            0x20,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0x55,
+            0xC0,
+        ]);
         let mut stub = Stub::new(&mut io);
-        let_assert!( Ok(Command::Sync(_)) = stub.wait_for_command(&mut dummy) );
+        let_assert!(Ok(Command::Sync(_)) = stub.wait_for_command(&mut dummy));
 
         // Check ReadReg command
         let mut io = MockIO::from_slice(&[
-            0xC0, 
-            0,          // direction
+            0xC0,
+            0, // direction
             CommandCode::ReadReg as u8,
-            4, 0,       // size
-            1, 0, 0, 0, // checksum
-            200, 0, 0, 0, // address
-            0xC0]);
+            4,
+            0, // size
+            1,
+            0,
+            0,
+            0, // checksum
+            200,
+            0,
+            0,
+            0, // address
+            0xC0,
+        ]);
         let mut stub = Stub::new(&mut io);
-        let_assert!( Ok(Command::ReadReg(address)) = stub.wait_for_command(&mut dummy) );
-        assert!( address == 200 );
+        let_assert!(Ok(Command::ReadReg(address)) = stub.wait_for_command(&mut dummy));
+        assert!(address == 200);
     }
 
     #[test]
     fn test_send_response() {
-        
         // Can write error response
         let mut io = MockIO::new();
         let mut stub = Stub::new(&mut io);
         let mut response = Response::new(CommandCode::FlashBegin);
         response.error(Error::BadDataChecksum);
-        let expected = &[0xC0, 1, CommandCode::FlashBegin as u8, 2,0, 0,0,0,0, 1, Error::BadDataChecksum as u8, 0xC0];
-        assert!( stub.send_response(&response) == Ok(()));
-        assert!( io.written() == expected);
+        let expected = &[
+            0xC0,
+            1,
+            CommandCode::FlashBegin as u8,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            Error::BadDataChecksum as u8,
+            0xC0,
+        ];
+        assert!(stub.send_response(&response) == Ok(()));
+        assert!(io.written() == expected);
 
         // Can write response with data
         let mut io = MockIO::new();
@@ -712,15 +807,36 @@ mod tests {
         let data = &[1, 2, 3, 4, 5, 6, 7, 8];
         let mut response = Response::new(CommandCode::FlashBegin);
         response.data(data);
-        let expected = &[0xC0, 1, CommandCode::FlashBegin as u8, 10,0, 0,0,0,0, 0,0, 1, 2, 3, 4, 5, 6, 7, 8, 0xC0];
-        assert!( stub.send_response(&response) == Ok(()));
-        assert!( io.written() == expected);
+        let expected = &[
+            0xC0,
+            1,
+            CommandCode::FlashBegin as u8,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            0xC0,
+        ];
+        assert!(stub.send_response(&response) == Ok(()));
+        assert!(io.written() == expected);
     }
 
     fn decorate_command<T>(data: T) -> Vec<u8> {
         let mut v = Vec::new();
         v.push(0xC0);
-        v.extend_from_slice( unsafe{ to_slice_u8(&data) } );
+        v.extend_from_slice(unsafe { to_slice_u8(&data) });
         v.push(0xC0);
         v
     }
@@ -738,18 +854,36 @@ mod tests {
     #[test]
     fn test_read_register() {
         let cmd = ReadRegCommand {
-            base: CommandBase { direction: 1, code: CommandCode::ReadReg, size: 4, checksum: 0 },
-            address: 200
+            base: CommandBase {
+                direction: 1,
+                code: CommandCode::ReadReg,
+                size: 4,
+                checksum: 0,
+            },
+            address: 200,
         };
         let mut io = MockIO::from_slice(&decorate_command(cmd));
         let mut stub = Stub::new(&mut io);
-        
+
         let ctx = target::read_register_context();
         ctx.expect().with(predicate::eq(200)).returning(|x| x + 1);
-        assert!( Ok(()) == stub.process_commands() );
+        assert!(Ok(()) == stub.process_commands());
 
-        let expect = &[0xC0, 1, CommandCode::ReadReg as u8, 2,0, 201,0,0,0, 0,0, 0xC0];
-        assert!( io.written() == expect );
+        let expect = &[
+            0xC0,
+            1,
+            CommandCode::ReadReg as u8,
+            2,
+            0,
+            201,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0xC0,
+        ];
+        assert!(io.written() == expect);
     }
 
     #[test]

--- a/src/serial_io.rs
+++ b/src/serial_io.rs
@@ -4,8 +4,7 @@ use esp32c3_hal::{
     pac::{self, UART0},
     prelude::*,
     serial::Instance,
-    Cpu,
-    Serial,
+    Cpu, Serial,
 };
 use heapless::spsc::Queue;
 
@@ -14,7 +13,7 @@ use crate::{protocol::InputIO, targets::esp32c3 as target};
 const RX_QUEUE_SIZE: usize = target::MAX_WRITE_BLOCK + 0x400;
 static mut RX_QUEUE: Queue<u8, RX_QUEUE_SIZE> = Queue::new();
 
-impl<'a, T: Instance> InputIO for Serial<T> {
+impl<T: Instance> InputIO for Serial<T> {
     fn recv(&mut self) -> u8 {
         loop {
             if let Some(byte) = unsafe { RX_QUEUE.dequeue() } {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-use mockall::automock;
-
 use crate::miniz_types::*;
 
 #[allow(unused)]
@@ -14,8 +11,14 @@ extern "C" {
     fn esp_rom_spiflash_read(src_addr: u32, data: *const u8, len: u32) -> i32;
     fn esp_rom_spiflash_unlock() -> i32;
     fn esp_rom_spiflash_attach(config: u32, legacy: bool);
-    fn esp_rom_spiflash_config_param(device_id: u32, chip_size: u32, block_size: u32, 
-                                     sector_size: u32, page_size: u32, status_mask: u32) -> u32;
+    fn esp_rom_spiflash_config_param(
+        device_id: u32,
+        chip_size: u32,
+        block_size: u32,
+        sector_size: u32,
+        page_size: u32,
+        status_mask: u32,
+    ) -> u32;
     fn uart_tx_one_char(byte: u8);
     fn uart_div_modify(uart_number: u32, baud_div: u32);
     fn ets_efuse_get_spiconfig() -> u32;
@@ -27,13 +30,12 @@ extern "C" {
     fn esp_rom_spiflash_write_encrypted(dest_addr: u32, data: *const u8, len: u32) -> i32;
 }
 
-
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 pub mod esp32c3 {
-    use super::*;
-    use crate::commands::*;
-    use crate::commands::Error::*;
     use core::ptr::{read_volatile, write_volatile};
+
+    use super::*;
+    use crate::commands::{Error::*, *};
 
     const SPI_BASE_REG: u32 = 0x60002000;
     const SPI_CMD_REG: u32 = SPI_BASE_REG + 0x00;
@@ -45,12 +47,12 @@ pub mod esp32c3 {
     const SPI0_EXT2_REG: u32 = SPI0_BASE_REG + 0x54;
 
     const SPI_ST: u32 = 0x7;
-    const SPI_FLASH_RDSR: u32 = 1<<27;
-    const STATUS_WIP_BIT: u32 = 1<<0;
-    const SPI_FLASH_WREN: u32 = 1<<30;
-    const SPI_FLASH_SE: u32 = 1<<24;
-    const SPI_FLASH_BE: u32 = 1<<23;
-    
+    const SPI_FLASH_RDSR: u32 = 1 << 27;
+    const STATUS_WIP_BIT: u32 = 1 << 0;
+    const SPI_FLASH_WREN: u32 = 1 << 30;
+    const SPI_FLASH_SE: u32 = 1 << 24;
+    const SPI_FLASH_BE: u32 = 1 << 23;
+
     const UART_BASE_REG: u32 = 0x60000000;
     const UART0_CLKDIV_REG: u32 = UART_BASE_REG + 0x14;
     const UART_CLKDIV_M: u32 = 0x000FFFFF;
@@ -64,11 +66,11 @@ pub mod esp32c3 {
     const GPIO_BASE_REG: u32 = 0x60004000;
     const GPIO_STRAP_REG: u32 = GPIO_BASE_REG + 0x38;
 
-    const FLASH_MAX_SIZE: u32 = 16*1024*1024;
+    const FLASH_MAX_SIZE: u32 = 16 * 1024 * 1024;
     const FLASH_PAGE_SIZE: u32 = 256;
     const FLASH_STATUS_MASK: u32 = 0xFFFF;
 
-    const SECURITY_INFO_BYTES : usize = 20;
+    const SECURITY_INFO_BYTES: usize = 20;
 
     fn get_uart_div(current_baud: u32, new_baud: u32) -> u32 {
         let clock_div_reg = read_register(UART0_CLKDIV_REG);
@@ -79,45 +81,52 @@ pub mod esp32c3 {
     }
 
     pub fn read_register(address: u32) -> u32 {
-        unsafe{ read_volatile(address as *const u32) }
+        unsafe { read_volatile(address as *const u32) }
     }
-    
+
     pub fn write_register(address: u32, value: u32) {
-        unsafe{ write_volatile(address as *mut _, value) }
+        unsafe { write_volatile(address as *mut _, value) }
     }
 
     pub fn spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> Result<(), Error> {
-        match unsafe{ esp_rom_spiflash_write(dest_addr, data, len) } {
+        match unsafe { esp_rom_spiflash_write(dest_addr, data, len) } {
             0 => Ok(()),
-            _ => Err(FailedSpiOp)
+            _ => Err(FailedSpiOp),
         }
     }
 
     pub fn spi_set_params(params: &SpiParams) -> Result<(), Error> {
-        let result = unsafe{ esp_rom_spiflash_config_param(
-            params.id,
-            params.total_size,
-            params.block_size,
-            params.sector_size,
-            params.page_size,
-            params.status_mask) };
+        let result = unsafe {
+            esp_rom_spiflash_config_param(
+                params.id,
+                params.total_size,
+                params.block_size,
+                params.sector_size,
+                params.page_size,
+                params.status_mask,
+            )
+        };
 
-        if result == 0 { Ok(()) } else { Err(FailedSpiOp) }
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(FailedSpiOp)
+        }
     }
 
     pub fn spi_attach(param: u32) {
-        unsafe{ esp_rom_spiflash_attach(param, false) };
+        unsafe { esp_rom_spiflash_attach(param, false) };
     }
 
     pub fn change_baudrate(old: u32, new: u32) {
-        unsafe{ uart_div_modify(0, get_uart_div(old, new)) };
+        unsafe { uart_div_modify(0, get_uart_div(old, new)) };
     }
-    
+
     pub fn erase_flash() -> Result<(), Error> {
         // Returns 1 or 2 in case of failure
-        match unsafe{ esp_rom_spiflash_erase_chip() } {
+        match unsafe { esp_rom_spiflash_erase_chip() } {
             0 => Ok(()),
-            _ => Err(FailedSpiOp)
+            _ => Err(FailedSpiOp),
         }
     }
 
@@ -129,14 +138,14 @@ pub mod esp32c3 {
         let command = if block { SPI_FLASH_BE } else { SPI_FLASH_SE };
         write_register(SPI_ADDR_REG, address);
         write_register(SPI_CMD_REG, command);
-        while read_register(SPI_CMD_REG) != 0 { }
+        while read_register(SPI_CMD_REG) != 0 {}
 
         spiflash_wait_for_ready();
     }
 
     fn wait_for_ready() {
-        while (read_register(SPI_EXT2_REG) & SPI_ST) != 0 { }
-        while (read_register(SPI0_EXT2_REG) & SPI_ST) != 0 { } // ESP32_OR_LATER
+        while (read_register(SPI_EXT2_REG) & SPI_ST) != 0 {}
+        while (read_register(SPI0_EXT2_REG) & SPI_ST) != 0 {} // ESP32_OR_LATER
     }
 
     fn spiflash_wait_for_ready() {
@@ -144,21 +153,21 @@ pub mod esp32c3 {
 
         write_register(SPI_RD_STATUS_REG, 0);
         write_register(SPI_CMD_REG, SPI_FLASH_RDSR);
-        while read_register(SPI_CMD_REG) != 0 { }
+        while read_register(SPI_CMD_REG) != 0 {}
         while (read_register(SPI_RD_STATUS_REG) & STATUS_WIP_BIT) != 0 {}
     }
 
     fn spi_write_enable() {
         write_register(SPI_CMD_REG, SPI_FLASH_WREN);
-        while read_register(SPI_CMD_REG) != 0 { }
+        while read_register(SPI_CMD_REG) != 0 {}
     }
 
-    pub fn flash_erase_block(address: u32 ) {
+    pub fn flash_erase_block(address: u32) {
         // unsafe{ esp_rom_spiflash_erase_block(address / FLASH_BLOCK_SIZE) };
         erase(address, true);
     }
 
-    pub fn flash_erase_sector(address: u32 ) {
+    pub fn flash_erase_sector(address: u32) {
         erase(address, false);
     }
 
@@ -167,7 +176,7 @@ pub mod esp32c3 {
             return Err(Err0x32);
         } else if size % FLASH_SECTOR_SIZE != 0 {
             return Err(Err0x33);
-        } else if unsafe{ esp_rom_spiflash_unlock() } != 0 {
+        } else if unsafe { esp_rom_spiflash_unlock() } != 0 {
             return Err(Err0x34);
         }
 
@@ -175,7 +184,7 @@ pub mod esp32c3 {
         let sector_end = sector_start + (size / FLASH_SECTOR_SIZE);
 
         for sector in sector_start..sector_end {
-            if unsafe{ esp_rom_spiflash_erase_sector(sector) } != 0 {
+            if unsafe { esp_rom_spiflash_erase_sector(sector) } != 0 {
                 return Err(Err0x35);
             }
         }
@@ -187,14 +196,14 @@ pub mod esp32c3 {
         let data_ptr = data.as_mut_ptr();
         let data_len = data.len() as u32;
 
-        match unsafe{ esp_rom_spiflash_read(address, data_ptr, data_len) } {
+        match unsafe { esp_rom_spiflash_read(address, data_ptr, data_len) } {
             0 => Ok(()),
-            _ => Err(Err0x63)
+            _ => Err(Err0x63),
         }
     }
 
     pub fn unlock_flash() -> Result<(), Error> {
-        if unsafe{ esp_rom_spiflash_unlock() } != 0 {
+        if unsafe { esp_rom_spiflash_unlock() } != 0 {
             Err(FailedSpiUnlock)
         } else {
             Ok(())
@@ -202,23 +211,22 @@ pub mod esp32c3 {
     }
 
     // ESP32S2_OR_LATER && !ESP32H2BETA2
-    pub fn get_security_info() -> Result<[u8; SECURITY_INFO_BYTES], Error>
-    {
+    pub fn get_security_info() -> Result<[u8; SECURITY_INFO_BYTES], Error> {
         let mut buf: [u8; SECURITY_INFO_BYTES] = [0; SECURITY_INFO_BYTES];
 
-        match unsafe{ GetSecurityInfoProc(0, 0, buf.as_mut_ptr()) } {
+        match unsafe { GetSecurityInfoProc(0, 0, buf.as_mut_ptr()) } {
             0 => Ok(buf),
             _ => Err(InvalidCommand), // Todo check ROM code for err val
         }
     }
 
     pub fn init() {
-        let mut spiconfig = unsafe{ ets_efuse_get_spiconfig() };
+        let mut spiconfig = unsafe { ets_efuse_get_spiconfig() };
 
         let strapping = read_register(GPIO_STRAP_REG);
 
         if spiconfig == 0 && (strapping & 0x1c) == 0x08 {
-            spiconfig = 1; /* HSPI flash mode */
+            spiconfig = 1; // HSPI flash mode
         }
 
         spi_attach(spiconfig);
@@ -240,40 +248,46 @@ pub mod esp32c3 {
     }
 
     pub fn delay_us(micro_seconds: u32) {
-        unsafe{ ets_delay_us(micro_seconds) };
+        unsafe { ets_delay_us(micro_seconds) };
     }
 
     pub fn write_encrypted_enable() {
-        unsafe{ esp_rom_spiflash_write_encrypted_enable(); }
+        unsafe {
+            esp_rom_spiflash_write_encrypted_enable();
+        }
     }
     pub fn write_encrypted_disable() {
-        unsafe{ esp_rom_spiflash_write_encrypted_disable(); }
+        unsafe {
+            esp_rom_spiflash_write_encrypted_disable();
+        }
     }
 
     pub fn write_encrypted(addr: u32, data: *const u8, len: u32) -> Result<(), Error> {
-        match unsafe{ esp_rom_spiflash_write_encrypted(addr, data, len) } {
-           0  => Ok(()),
-           _ => Err(FailedSpiOp)
+        match unsafe { esp_rom_spiflash_write_encrypted(addr, data, len) } {
+            0 => Ok(()),
+            _ => Err(FailedSpiOp),
         }
     }
 
     pub fn decompress(
-        r: *mut tinfl_decompressor, 
-        in_buf: *const u8, 
-        in_buf_size: *mut usize, 
-        out_buf_start: *mut u8, 
-        out_buf_next: *mut u8, 
-        out_buf_size: *mut usize, 
-        flags: u32
+        r: *mut tinfl_decompressor,
+        in_buf: *const u8,
+        in_buf_size: *mut usize,
+        out_buf_start: *mut u8,
+        out_buf_next: *mut u8,
+        out_buf_size: *mut usize,
+        flags: u32,
     ) -> TinflStatus {
-        unsafe { tinfl_decompress(
-            r, 
-            in_buf,
-            in_buf_size,
-            out_buf_start,
-            out_buf_next,
-            out_buf_size,
-            flags,
-        ) }
+        unsafe {
+            tinfl_decompress(
+                r,
+                in_buf,
+                in_buf_size,
+                out_buf_start,
+                out_buf_next,
+                out_buf_size,
+                flags,
+            )
+        }
     }
 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -38,7 +38,7 @@ pub mod esp32c3 {
     use crate::commands::{Error, SpiParams};
 
     const SPI_BASE_REG: u32 = 0x60002000;
-    const SPI_CMD_REG: u32 = SPI_BASE_REG + 0x00;
+    const SPI_CMD_REG: u32 = SPI_BASE_REG;
     const SPI_ADDR_REG: u32 = SPI_BASE_REG + 0x04;
     const SPI_RD_STATUS_REG: u32 = SPI_BASE_REG + 0x2C;
     const SPI_EXT2_REG: u32 = SPI_BASE_REG + 0x54;


### PR DESCRIPTION
No real code changes here, I've split the work up across commits for review purposes:

- Run `cargo fmt` on the repository to make everything homogenous
- Remove glob imports from modules (I think these make the code harder to reason about when reading)
- Address any `stable` clippy warnings (this is in preparation of adding CI)

I have a separate branch ready with the CI configuration as well, however it will fail until this PR is merged so I've held off on opening a PR for it.