### PR TITLE
Put `dprint` module behind `dprint` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "assert2"
@@ -547,9 +547,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -668,15 +668,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "predicates"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -728,18 +728,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "scopeguard"
@@ -856,15 +856,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "spin"
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -931,9 +931,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "usb-device"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ esp32s2 = ["esp32s2-hal", "esp-backtrace/esp32s2"]
 esp32s3 = ["esp32s3-hal", "esp-backtrace/esp32s3"]
 esp32c3 = ["esp32c3-hal", "esp-backtrace/esp32c3"]
 esp32c2 = ["esp32c2-hal", "esp-backtrace/esp32c2"]
+dprint = []
 
 [profile.release]
 strip = true

--- a/Makefile_patched.patch
+++ b/Makefile_patched.patch
@@ -1,0 +1,65 @@
+diff --git a/flasher_stub/Makefile b/flasher_stub/Makefile
+index 4e4f4d9..c794e29 100644
+--- a/flasher_stub/Makefile
++++ b/flasher_stub/Makefile
+@@ -72,7 +72,7 @@ STUB_ELF_32H2 = $(BUILD_DIR)/$(STUB)_32h2.elf
+ 
+ .PHONY: all clean embed
+ 
+-all: $(STUB_ELF_8266) $(STUB_ELF_32) $(STUB_ELF_32S2) $(STUB_ELF_32S3_BETA_2) $(STUB_ELF_32S3) $(STUB_ELF_32C3) $(STUB_ELF_32C6BETA) $(STUB_ELF_32H2_BETA_1) $(STUB_ELF_32H2_BETA_2) $(STUB_ELF_32C2) $(STUB_ELF_32C6) $(STUB_ELF_32H2)
++all: $(STUB_ELF_32) $(STUB_ELF_32S2) $(STUB_ELF_32S3_BETA_2) $(STUB_ELF_32S3) $(STUB_ELF_32C3) $(STUB_ELF_32C6BETA) $(STUB_ELF_32H2_BETA_1) $(STUB_ELF_32H2_BETA_2) $(STUB_ELF_32C2) $(STUB_ELF_32C6) $(STUB_ELF_32H2)
+ 	@echo "  WRAP $^ -> $(BUILD_DIR)"
+ 	$(Q) $(WRAP_STUB) $^
+ 
+@@ -88,17 +88,14 @@ CFLAGS_ESPRISCV32 = -std=c99 -Wall -Werror -Os \
+          -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld
+ LDLIBS = -lgcc
+ 
+-$(STUB_ELF_8266): $(SRCS) $(SRCS_8266) $(BUILD_DIR) ld/stub_8266.ld | Makefile
+-	@echo "  CC(8266)   $^ -> $@"
+-	$(Q) $(CROSS_8266)gcc $(CFLAGS) -DESP8266=1 -Tstub_8266.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
+ 
+ $(STUB_ELF_32): $(SRCS) $(BUILD_DIR) ld/stub_32.ld | Makefile
+ 	@echo "  CC(32)   $^ -> $@"
+-	$(Q) $(CROSS_32)gcc $(CFLAGS) -DESP32=1 -Tstub_32.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
++	cp ../../target/xtensa-esp32-none-elf/release/flasher-stub build/stub_flasher_32.elf
+ 
+ $(STUB_ELF_32S2): $(SRCS) $(BUILD_DIR) ld/stub_32s2.ld
+ 	@echo "  CC(32S2)   $^ -> $@"
+-	$(Q) $(CROSS_32S2)gcc $(CFLAGS) -DESP32S2=1 -Tstub_32s2.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
++	cp ../../target/xtensa-esp32s2-none-elf/release/flasher-stub build/stub_flasher_32s2.elf
+ 
+ $(STUB_ELF_32S3_BETA_2): $(SRCS) $(BUILD_DIR) ld/stub_32s3_beta_2.ld
+ 	@echo "  CC(32S3)   $^ -> $@"
+@@ -106,11 +103,11 @@ $(STUB_ELF_32S3_BETA_2): $(SRCS) $(BUILD_DIR) ld/stub_32s3_beta_2.ld
+ 
+ $(STUB_ELF_32S3): $(SRCS) $(BUILD_DIR) ld/stub_32s3.ld
+ 	@echo "  CC(32S3)   $^ -> $@"
+-	$(Q) $(CROSS_32S3)gcc $(CFLAGS) -DESP32S3=1 -Tstub_32s3.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
++	cp ../../target/xtensa-esp32s3-none-elf/release/flasher-stub build/stub_flasher_32s3.elf
+ 
+ $(STUB_ELF_32C3): $(SRCS) $(BUILD_DIR) ld/stub_32c3.ld
+ 	@echo "  CC(32C3)   $^ -> $@"
+-	$(Q) $(CROSS_32C3)gcc $(CFLAGS_ESPRISCV32) -DESP32C3=1 -Tstub_32c3.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
++	cp ../../target/riscv32imc-unknown-none-elf/release/flasher-stub build/stub_flasher_32c3.elf
+ 
+ $(STUB_ELF_32C6BETA): $(SRCS) $(BUILD_DIR) ld/stub_32c6_beta.ld
+ 	@echo "  CC(32C6BETA)   $^ -> $@"
+@@ -126,7 +123,7 @@ $(STUB_ELF_32H2_BETA_2): $(SRCS) $(BUILD_DIR) ld/stub_32h2_beta_2.ld
+ 
+ $(STUB_ELF_32C2): $(SRCS) $(BUILD_DIR) ld/stub_32c2.ld
+ 	@echo "  CC(32C2)   $^ -> $@"
+-	$(Q) $(CROSS_32C2)gcc $(CFLAGS_ESPRISCV32) -DESP32C2=1 -Tstub_32c2.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
++	cp ../../target/riscv32imc-unknown-none-elf/release/flasher-stub build/stub_flasher_32c2.elf
+ 
+ $(STUB_ELF_32C6): $(SRCS) $(BUILD_DIR) ld/stub_32c6.ld
+ 	@echo "  CC(32C6)   $^ -> $@"
+@@ -136,7 +133,7 @@ $(STUB_ELF_32H2): $(SRCS) $(BUILD_DIR) ld/stub_32h2.ld
+ 	@echo "  CC(32H2)   $^ -> $@"
+ 	$(Q) $(CROSS_32H2)gcc $(CFLAGS_ESPRISCV32) -DESP32H2=1 -Tstub_32h2.ld -Wl,-Map=$(@:.elf=.map) -o $@ $(filter %.c, $^) $(LDLIBS)
+ 
+-embed: $(STUB_ELF_8266) $(STUB_ELF_32) $(STUB_ELF_32S2) $(STUB_ELF_32S3_BETA_2) $(STUB_ELF_32S3) $(STUB_ELF_32C3) $(STUB_ELF_32C6BETA) $(STUB_ELF_32H2_BETA_1) $(STUB_ELF_32H2_BETA_2) $(STUB_ELF_32C2) $(STUB_ELF_32C6) $(STUB_ELF_32H2)
++embed: $(STUB_ELF_32) $(STUB_ELF_32S2) $(STUB_ELF_32S3_BETA_2) $(STUB_ELF_32S3) $(STUB_ELF_32C3) $(STUB_ELF_32C6BETA) $(STUB_ELF_32H2_BETA_1) $(STUB_ELF_32H2_BETA_2) $(STUB_ELF_32C2) $(STUB_ELF_32C6) $(STUB_ELF_32H2)
+ 	@echo "  WRAP $^ -> $(ESPTOOL_STUBS_DIR)"
+ 	$(Q) $(WRAP_STUB) --embed $^
+ 

--- a/README.md
+++ b/README.md
@@ -52,20 +52,31 @@ In order to run `test_esptool.py` follow steps below:
 git clone https://github.com/espressif/esptool
 ```
 
-- Navigate to `esptool`, checkout version for which patch located in `esp-flasher-stub` directory was created and apply it.
+- Run patched Makefile
 
 ```
-cd esptool
-git checkout 6488ebb
-git am ../../esp-flasher-stub/esptool.patch
-```
-
-- Regenerate `stub_flasher.py` by running patched Makefile and run the tests
+cd esptool/flasher_stub/
+git apply Makefile_patched.patch
+make -C .
+- Run tests
 
 ```
-cd test
-make -C ../flasher_stub/ && python test_esptool.py /dev/ttyUSB0 esp32c3 115200
+cd ../test
+pytest test_esptool.py --port /dev/ttyUSB0 --chip esp32 --baud 115200
 ```
+
+## Debug logs
+
+In order to use `debug logs` you have to build the project with `dprint` feature, for example:
+`cargo build --release --target riscv32imc-unknown-none-elf --features esp32c3,dprint`
+
+and then you can view logs using, for example `screen`:
+`sudo screen /dev/ttyUSB2 115200`
+
+> **Warning**
+>
+> For `ESP32` and `ESP32S2`, please use `baud rate` 57600 instead:
+> `sudo screen /dev/ttyUSB2 57600`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ git clone https://github.com/espressif/esptool
 cd esptool/flasher_stub/
 git apply Makefile_patched.patch
 make -C .
+```
+
 - Run tests
 
 ```
@@ -67,7 +69,7 @@ pytest test_esptool.py --port /dev/ttyUSB0 --chip esp32 --baud 115200
 
 ## Debug logs
 
-In order to use `debug logs` you have to build the project with `dprint` feature, for example:
+In order to use `debug logs` you have to build the project with `dprint` feature, for example:\
 `cargo build --release --target riscv32imc-unknown-none-elf --features esp32c3,dprint`
 
 and then you can view logs using, for example `screen`:

--- a/src/dprint.rs
+++ b/src/dprint.rs
@@ -66,12 +66,8 @@ macro_rules! dprint {
 #[macro_export]
 #[cfg(not(feature = "dprint"))]
 macro_rules! dprint {
-    ($s:expr) => {
-        
-    };
-    ($($arg:tt)*) => {
-        
-    };
+    ($s:expr) => {};
+    ($($arg:tt)*) => {};
 }
 
 /// Macro for sending a formatted string to UART1 for debugging, with a newline.
@@ -101,19 +97,12 @@ macro_rules! dprintln {
     };
 }
 
-
 #[macro_export]
 #[cfg(not(feature = "dprint"))]
 macro_rules! dprintln {
-    () => {
-        
-    };
-    ($fmt:expr) => {
-        
-    };
-    ($fmt:expr, $($arg:tt)*) => {
-       
-    };
+    () => {};
+    ($fmt:expr) => {};
+    ($fmt:expr, $($arg:tt)*) => {};
 }
 
 /// Macro for flushing the UART1 TX buffer

--- a/src/dprint.rs
+++ b/src/dprint.rs
@@ -45,6 +45,7 @@ impl core::fmt::Write for DebugLog {
 
 /// Macro for sending a formatted string to UART1 for debugging
 #[macro_export]
+#[cfg(feature = "dprint")]
 macro_rules! dprint {
     ($s:expr) => {
         #[allow(unused_unsafe)]
@@ -62,8 +63,20 @@ macro_rules! dprint {
     };
 }
 
+#[macro_export]
+#[cfg(not(feature = "dprint"))]
+macro_rules! dprint {
+    ($s:expr) => {
+        
+    };
+    ($($arg:tt)*) => {
+        
+    };
+}
+
 /// Macro for sending a formatted string to UART1 for debugging, with a newline.
 #[macro_export]
+#[cfg(feature = "dprint")]
 macro_rules! dprintln {
     () => {
         #[allow(unused_unsafe)]
@@ -85,6 +98,21 @@ macro_rules! dprintln {
             use core::fmt::Write;
             $crate::dprint::DEBUG_LOG.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).unwrap();
         }
+    };
+}
+
+
+#[macro_export]
+#[cfg(not(feature = "dprint"))]
+macro_rules! dprintln {
+    () => {
+        
+    };
+    ($fmt:expr) => {
+        
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+       
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,19 +2,13 @@
 #![no_std]
 
 use esp_backtrace as _;
+#[cfg(feature = "dprint")]
+use flasher_stub::hal::serial::{
+    config::{Config, DataBits, Parity, StopBits},
+    TxRxPins,
+};
 use flasher_stub::{
-    hal::{
-        clock::ClockControl,
-        interrupt,
-        pac,
-        prelude::*,
-        serial::{
-            config::{Config, DataBits, Parity, StopBits},
-            TxRxPins,
-        },
-        Serial,
-        IO,
-    },
+    hal::{clock::ClockControl, interrupt, pac, prelude::*, Serial, IO},
     protocol::Stub,
     targets,
 };
@@ -34,28 +28,34 @@ fn main() -> ! {
     let system = peripherals.DPORT.split();
 
     #[cfg(not(feature = "esp32c2"))]
+    #[allow(unused)]
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze(); // TODO: configure clocks for all chips
     #[cfg(feature = "esp32c2")]
+    #[allow(unused)]
     let clocks = ClockControl::configure(
         system.clock_control,
         flasher_stub::hal::clock::CpuClock::Clock120MHz,
     )
     .freeze();
 
+    #[allow(unused)]
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = TxRxPins::new_tx_rx(
-        io.pins.gpio2.into_push_pull_output(),
-        io.pins.gpio0.into_floating_input(),
+
+    #[cfg(feature = "dprint")]
+    let _ = Serial::new_with_config(
+        peripherals.UART1,
+        Some(Config {
+            baudrate: 115200,
+            data_bits: DataBits::DataBits8,
+            parity: Parity::ParityNone,
+            stop_bits: StopBits::STOP1,
+        }),
+        Some(TxRxPins::new_tx_rx(
+            io.pins.gpio2.into_push_pull_output(),
+            io.pins.gpio0.into_floating_input(),
+        )),
+        &clocks,
     );
-
-    let config = Config {
-        baudrate: 115200,
-        data_bits: DataBits::DataBits8,
-        parity: Parity::ParityNone,
-        stop_bits: StopBits::STOP1,
-    };
-
-    let _ = Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     let mut serial = Serial::new(peripherals.UART0);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,19 @@
 #![no_std]
 
 use esp_backtrace as _;
-#[cfg(feature = "dprint")]
-use flasher_stub::hal::serial::{
-    config::{Config, DataBits, Parity, StopBits},
-    TxRxPins,
-};
 use flasher_stub::{
-    hal::{clock::ClockControl, interrupt, pac, prelude::*, Serial, IO},
+    hal::{
+        clock::ClockControl,
+        interrupt,
+        pac,
+        prelude::*,
+        serial::{
+            config::{Config, DataBits, Parity, StopBits},
+            TxRxPins,
+        },
+        Serial,
+        IO,
+    },
     protocol::Stub,
     targets,
 };
@@ -28,34 +34,28 @@ fn main() -> ! {
     let system = peripherals.DPORT.split();
 
     #[cfg(not(feature = "esp32c2"))]
-    #[allow(unused)]
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze(); // TODO: configure clocks for all chips
     #[cfg(feature = "esp32c2")]
-    #[allow(unused)]
     let clocks = ClockControl::configure(
         system.clock_control,
         flasher_stub::hal::clock::CpuClock::Clock120MHz,
     )
     .freeze();
 
-    #[allow(unused)]
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    #[cfg(feature = "dprint")]
-    let _ = Serial::new_with_config(
-        peripherals.UART1,
-        Some(Config {
-            baudrate: 115200,
-            data_bits: DataBits::DataBits8,
-            parity: Parity::ParityNone,
-            stop_bits: StopBits::STOP1,
-        }),
-        Some(TxRxPins::new_tx_rx(
-            io.pins.gpio2.into_push_pull_output(),
-            io.pins.gpio0.into_floating_input(),
-        )),
-        &clocks,
+    let pins = TxRxPins::new_tx_rx(
+        io.pins.gpio2.into_push_pull_output(),
+        io.pins.gpio0.into_floating_input(),
     );
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let _ = Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     let mut serial = Serial::new(peripherals.UART0);
 


### PR DESCRIPTION
Don't build `dprint` module by default
Instead of `boot_defaults` use explicit clock for `C2`, `C3` and` S3`
Update README

Note: For some reason, `ESP32` and `S2` work _ONLY_  with `boot_defaults` clocks, we will have to investigate it in more detail.
closes: #8 