### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,11 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses:dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           target: riscv32imc-unknown-none-elf
           toolchain: ${{ matrix.toolchain }}
           components: rust-src
-          default: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -68,11 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses:dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -90,13 +86,11 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses:dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           target: riscv32imc-unknown-none-elf
           toolchain: ${{ matrix.toolchain }}
-          components: clippy, rust-src
-          default: true
+          components: clippy
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
@@ -135,13 +129,11 @@ jobs:
         chips: [esp32c2, esp32c3]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses:dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           target: riscv32imc-unknown-none-elf
           toolchain: "1.60.0"
           components: rust-src
-          default: true
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
-      - uses:dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
           toolchain: ${{ matrix.toolchain }}
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses:dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt
@@ -86,7 +86,7 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
-      - uses:dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
           toolchain: ${{ matrix.toolchain }}
@@ -129,7 +129,7 @@ jobs:
         chips: [esp32c2, esp32c3]
     steps:
       - uses: actions/checkout@v2
-      - uses:dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
           toolchain: "1.60.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         chips: [esp32c3, esp32c2]
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
@@ -46,7 +46,7 @@ jobs:
     env:
       RUSTFLAGS: '--cfg target_has_atomic="8" --cfg target_has_atomic="16" --cfg target_has_atomic="32" --cfg target_has_atomic="ptr"'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
@@ -65,7 +65,7 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
@@ -85,7 +85,7 @@ jobs:
         chips: [esp32c3, esp32c2]
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
@@ -105,7 +105,7 @@ jobs:
       matrix:
         chips: [esp32, esp32s2, esp32s3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
@@ -128,7 +128,7 @@ jobs:
       matrix:
         chips: [esp32c2, esp32c3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
@@ -149,7 +149,7 @@ jobs:
     env:
       RUSTFLAGS: '--cfg target_has_atomic="8" --cfg target_has_atomic="16" --cfg target_has_atomic="32" --cfg target_has_atomic="ptr"'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,15 @@ jobs:
       fail-fast: false
       matrix:
         chips: [esp32c3, esp32c2]
-        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: nightly
           components: rust-src
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
+      - name: cargo check
+        run: cargo check --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
 
   check-xtensa:
     name: Check Xtensa
@@ -42,7 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         chips: [esp32, esp32s2, esp32s3]
-        toolchain: [stable, nightly]
     env:
       RUSTFLAGS: '--cfg target_has_atomic="8" --cfg target_has_atomic="16" --cfg target_has_atomic="32" --cfg target_has_atomic="ptr"'
     steps:
@@ -52,11 +48,9 @@ jobs:
           default: true
           ldproxy: false
           buildtargets: ${{ matrix.chips }}
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}
 
   # --------------------------------------------------------------------------
   # Formatting & Clippy
@@ -70,11 +64,9 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
 
   clippy-riscv:
     name: Run clippy on RISC-V builds
@@ -83,19 +75,16 @@ jobs:
       fail-fast: false
       matrix:
         chips: [esp32c3, esp32c2]
-        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features ${{ matrix.chips }} --target riscv32imc-unknown-none-elf -- --no-deps
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo clippy
+        run: cargo clippy --features ${{ matrix.chips }} --target riscv32imc-unknown-none-elf -- --no-deps
 
   clippy-xtensa:
     name: Run clippy on Xtensa builds
@@ -111,11 +100,9 @@ jobs:
           default: true
           ldproxy: false
           buildtargets: ${{ matrix.chips }}
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -Zbuild-std=core --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }} -- --no-deps
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo clippy
+        run: cargo clippy -Zbuild-std=core --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }} -- --no-deps
 
   # --------------------------------------------------------------------------
   # MSRV Check
@@ -134,10 +121,8 @@ jobs:
           target: riscv32imc-unknown-none-elf
           toolchain: "1.60.0"
           components: rust-src
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
+      - name: cargo check
+        run: cargo check --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
 
   msrv-xtensa:
     name: Check Xtensa MSRV
@@ -156,8 +141,6 @@ jobs:
           ldproxy: false
           buildtargets: ${{ matrix.chips }}
           version: "1.60.0"
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}


### PR DESCRIPTION
- Bump `actions/checkout`
- Replace `actions-rs/toolchain` by `dtolnay/rust-toolchain`
- Remove unnecessary matrix elements
- Avoid using `actions-rs/cargo`