### PR TITLE
Create an `xtask` package to build the stubs and convert them to JSON

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
-[target.'cfg(target_arch="riscv32")']
-rustflags = [ "-C", "link-args=-Map=target/stub.map" ]
+[alias]
+xtask = "run --package xtask --"
 
-[target.'cfg(target_arch="xtensa")']
-rustflags = [ "-Clink-args=-Wl,-Map=target/stub.map" ]
+[target.'cfg(target_arch = "riscv32")']
+rustflags = ["-C", "link-args=-Map=target/stub.map"]
 
-[unstable]
-build-std = ["core"]
+[target.'cfg(target_arch = "xtensa")']
+rustflags = ["-C", "link-args=-Wl,-Map=target/stub.map"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,53 +11,117 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 jobs:
   # --------------------------------------------------------------------------
   # Cargo check
 
   check-riscv:
-    name: Check RISC-V
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        chips: [esp32c3, esp32c2]
+        build:
+          [
+            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+          ]
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
-          target: riscv32imc-unknown-none-elf
+          target: ${{ matrix.build.target }}
           toolchain: nightly
           components: rust-src
+      - uses: Swatinem/rust-cache@v2
       - name: cargo check
-        run: cargo check --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
+        run: cargo check -Zbuild-std=core --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }}
 
   check-xtensa:
-    name: Check Xtensa
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        chips: [esp32, esp32s2, esp32s3]
-    env:
-      RUSTFLAGS: '--cfg target_has_atomic="8" --cfg target_has_atomic="16" --cfg target_has_atomic="32" --cfg target_has_atomic="ptr"'
+        build:
+          [
+            { chip: "esp32", target: "xtensa-esp32-none-elf" },
+            { chip: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { chip: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+          ]
+
     steps:
       - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
           ldproxy: false
-          buildtargets: ${{ matrix.chips }}
+          buildtargets: ${{ matrix.build.chip }}
       - uses: Swatinem/rust-cache@v2
       - name: cargo check
-        run: cargo check --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}
+        run: cargo check -Zbuild-std=core --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }}
 
   # --------------------------------------------------------------------------
   # Formatting & Clippy
 
-  rustfmt:
-    name: Check formatting
+  clippy-riscv:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build:
+          [
+            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: ${{ matrix.build.target }}
+          toolchain: stable
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo clippy
+        run: cargo clippy --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }} -- --no-deps
+
+  clippy-xtensa:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          [
+            { chip: "esp32", target: "xtensa-esp32-none-elf" },
+            { chip: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { chip: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          ldproxy: false
+          buildtargets: ${{ matrix.build.chip }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo clippy
+        run: cargo clippy -Zbuild-std=core --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }} -- --no-deps
+
+  rustfmt:
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -68,79 +132,52 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
-  clippy-riscv:
-    name: Run clippy on RISC-V builds
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        chips: [esp32c3, esp32c2]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf
-          toolchain: stable
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo clippy
-        run: cargo clippy --features ${{ matrix.chips }} --target riscv32imc-unknown-none-elf -- --no-deps
-
-  clippy-xtensa:
-    name: Run clippy on Xtensa builds
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        chips: [esp32, esp32s2, esp32s3]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          default: true
-          ldproxy: false
-          buildtargets: ${{ matrix.chips }}
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo clippy
-        run: cargo clippy -Zbuild-std=core --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }} -- --no-deps
-
   # --------------------------------------------------------------------------
   # MSRV Check
 
   msrv-riscv:
-    name: Check RISC-V MSRV
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        chips: [esp32c2, esp32c3]
+        build:
+          [
+            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+          ]
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
-          target: riscv32imc-unknown-none-elf
+          target: ${{ matrix.build.target }}
           toolchain: "1.60.0"
           components: rust-src
       - name: cargo check
-        run: cargo check --target=riscv32imc-unknown-none-elf --features ${{ matrix.chips }}
+        run: cargo check --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }}
 
   msrv-xtensa:
-    name: Check Xtensa MSRV
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        chips: [esp32, esp32s2, esp32s3]
-    env:
-      RUSTFLAGS: '--cfg target_has_atomic="8" --cfg target_has_atomic="16" --cfg target_has_atomic="32" --cfg target_has_atomic="ptr"'
+        build:
+          [
+            { chip: "esp32", target: "xtensa-esp32-none-elf" },
+            { chip: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { chip: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+          ]
+
     steps:
       - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
           ldproxy: false
-          buildtargets: ${{ matrix.chips }}
+          buildtargets: ${{ matrix.build.chip }}
           version: "1.60.0"
       - uses: Swatinem/rust-cache@v2
       - name: cargo check
-        run: cargo check --target=xtensa-${{ matrix.chips }}-none-elf --features ${{ matrix.chips }}
+        run: cargo check -Zbuild-std=core --target=${{ matrix.build.target }} --features=${{ matrix.build.chip }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Release (RISC-V)
+
+  release-riscv:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          [
+            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: ${{ matrix.build.target }}
+          toolchain: nightly
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+
+      - name: build & wrap (${{ matrix.build.chip }})
+        run: cargo xtask wrap ${{ matrix.build.chip }}
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ env.GITHUB_TOKEN }}
+          file: "${{ matrix.build.chip }}.json"
+          tag: ${{ github.ref }}
+
+  # --------------------------------------------------------------------------
+  # Release (Xtensa)
+
+  release-xtensa:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          [
+            { chip: "esp32", target: "xtensa-esp32-none-elf" },
+            { chip: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { chip: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          ldproxy: false
+          buildtargets: ${{ matrix.build.chip }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: build & wrap (${{ matrix.build.chip }})
+        run: cargo xtask wrap ${{ matrix.build.chip }}
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ env.GITHUB_TOKEN }}
+          file: "${{ matrix.build.chip }}.json"
+          tag: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target/
 .vscode/
 .DS_Store
 *.swp
+
+# Ignore generated JSON stub files
+*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,67 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.68"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "assert2"
@@ -37,7 +86,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -55,7 +104,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -79,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,10 +149,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-isa-parser"
@@ -108,8 +248,8 @@ dependencies = [
  "anyhow",
  "enum-as-inner",
  "regex",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
 ]
 
 [[package]]
@@ -149,7 +289,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -160,7 +300,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -171,9 +311,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -219,7 +359,41 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -272,7 +446,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -511,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -525,10 +699,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -540,6 +749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,9 +762,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -560,6 +781,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matches"
@@ -615,7 +842,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -627,7 +854,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -665,6 +892,12 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "paste"
@@ -711,7 +944,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -728,18 +961,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -752,9 +985,21 @@ checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -763,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "riscv"
@@ -820,7 +1065,7 @@ checksum = "f38509d7b17c2f604ceab3e5ff8ac97bb8cd2f544688c512be75c715edaf4daf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -843,10 +1088,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
+name = "ryu"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "scopeguard"
@@ -859,12 +1124,40 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.166"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "spin"
@@ -894,6 +1187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +1205,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -918,10 +1233,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "thiserror"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
 
 [[package]]
 name = "typenum"
@@ -940,6 +1295,12 @@ name = "usb-device"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcell"
@@ -976,10 +1337,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xmas-elf"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f820cc767d65b32eef9d7ce7201448f28501c59edc55d47b71375fea579fc2df"
+dependencies = [
+ "zero",
+]
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "env_logger",
+ "log",
+ "serde_json",
+ "strum 0.25.0",
+ "xmas-elf",
+]
 
 [[package]]
 name = "xtensa-atomic-emulation-trap"
@@ -1023,7 +1482,7 @@ checksum = "21a8200930e2dbd515c231f7a46033bd6dfe1497a8e9a539878f0de8f0cd730b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1031,3 +1490,9 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zero"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ opt-level = "s" # temporary because of https://github.com/llvm/llvm-project/issu
 codegen-units = 1
 lto = true
 panic = "abort"
+
+[workspace]
+members = ["xtask"]

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ In order to build the flasher stub manually, you must specify the appropriate to
 cargo +esp build --release --features=esp32 --target=xtensa-esp32-none-elf
 
 # ESP32-C2
-cargo build --release --features=esp32c2 --target=riscv32imc-unknown-none-elf
+cargo +nightly build --release --features=esp32c2 --target=riscv32imc-unknown-none-elf
 
 # ESP32-C3
-cargo build --release --features=esp32c3 --target=riscv32imc-unknown-none-elf
+cargo +nightly build --release --features=esp32c3 --target=riscv32imc-unknown-none-elf
 
 # ESP32-S2
 cargo +esp build --release --features=esp32s2 --target=xtensa-esp32s2-none-elf

--- a/README.md
+++ b/README.md
@@ -2,83 +2,86 @@
 
 [![GitHub Workflow Status](https://github.com/esp-rs/esp-println/actions/workflows/ci.yml/badge.svg)](https://github.com/esp-rs/esp-println/actions/workflows/ci.yml)
 ![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&labelColor=1C2C2E&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 Rust implementation of flasher stub located in [esptool](https://github.com/espressif/esptool/).
 
-Supports the ESP32, ESP32-C2/C3, and ESP32-S2/S3. Currently `UART` is the only supported transport mode, however support for more is planned.
+Supports the ESP32, ESP32-C2/C3, and ESP32-S2/S3. Currently `UART` is the only supported transport mode, however support for other modes is planned.
 
 ## Quickstart
 
-In order to build the flasher stub, you must provide a feature to `cargo` selecting the device, and additionally specify the target.
+To ease the building process we have included a `build` subcommand in the `xtask` package which will apply all the appropriate build configuration for one or more devices:
 
-#### ESP32
-
-```
- cargo +esp build --features=esp32 --target=xtensa-esp32-none-elf --release
-```
-
-#### ESP32-C2
-
-```
- cargo build --features=esp32c2 --target=riscv32imc-unknown-none-elf --release
+```bash
+cargo xtask build esp32
+cargo xtask build esp32c2 esp32c3
 ```
 
-#### ESP32-C3
+In order to build the flasher stub manually, you must specify the appropriate toolchain, provide a feature to `cargo` selecting the device, and additionally specify the target:
 
-```
- cargo build --features=esp32c3 --target=riscv32imc-unknown-none-elf --release
+```bash
+# ESP32
+cargo +esp build --release --features=esp32 --target=xtensa-esp32-none-elf
+
+# ESP32-C2
+cargo build --release --features=esp32c2 --target=riscv32imc-unknown-none-elf
+
+# ESP32-C3
+cargo build --release --features=esp32c3 --target=riscv32imc-unknown-none-elf
+
+# ESP32-S2
+cargo +esp build --release --features=esp32s2 --target=xtensa-esp32s2-none-elf
+
+# ESP32-S3
+cargo +esp build --release --features=esp32s3 --target=xtensa-esp32s3-none-elf
 ```
 
-#### ESP32-S2
+In order to generate the JSON stub files for one or more devices, you can again use the `xtask` package:
 
-```
- cargo +esp build --features=esp32s2 --target=xtensa-esp32s2-none-elf --release
-```
-
-#### ESP32-S3
-
-```
- cargo +esp build --features=esp32s3 --target=xtensa-esp32s3-none-elf --release
+```bash
+cargo xtask wrap esp32c3
+cargo xtask wrap esp32 esp32s2 esp32s3
 ```
 
 ## Testing
 
 In order to run `test_esptool.py` follow steps below:
 
-- Build `esp-flasher-stub` as described in the build section above.
+- Build `esp-flasher-stub` as described in the section above.
 - Clone `esptool` to the same directory where `esp-flasher-stub` resides.
-
-```
-git clone https://github.com/espressif/esptool
-```
-
 - Run patched Makefile
+- Run tests
 
-```
+```bash
+git clone https://github.com/espressif/esptool
 cd esptool/flasher_stub/
 git apply Makefile_patched.patch
 make -C .
-```
-
-- Run tests
-
-```
 cd ../test
 pytest test_esptool.py --port /dev/ttyUSB0 --chip esp32 --baud 115200
 ```
 
 ## Debug logs
 
-In order to use `debug logs` you have to build the project with `dprint` feature, for example:\
-`cargo build --release --target riscv32imc-unknown-none-elf --features esp32c3,dprint`
+In order to use debug logs you have to build the project with `dprint` feature, for example:
 
-and then you can view logs using, for example `screen`:
-`sudo screen /dev/ttyUSB2 115200`
+```bash
+cargo build --release --target=riscv32imc-unknown-none-elf --features=esp32c3,dprint
+```
+
+Then you can view logs using, for example `screen`:
+
+```bash
+screen /dev/ttyUSB2 115200
+```
 
 > **Warning**
 >
-> For `ESP32` and `ESP32S2`, please use `baud rate` 57600 instead:
-> `sudo screen /dev/ttyUSB2 57600`
+> For ESP32 and ESP32-S2, please use a baud rate of 57,600 instead:
+>
+> ```bash
+> screen /dev/ttyUSB2 57600
+> ```
 
 ## License
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name    = "xtask"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow         = "1.0.71"
+cargo_metadata = "0.15.4"
+clap           = { version = "4.3.11", features = ["derive"] }
+env_logger     = "0.10.0"
+log            = "0.4.19"
+serde_json     = "1.0.100"
+strum          = { version = "0.25.0", features = ["derive"] }
+xmas-elf       = "0.9.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,192 @@
+use std::{
+    fs,
+    iter,
+    path::{Path, PathBuf},
+    process::{exit, Command, ExitStatus, Stdio},
+};
+
+use anyhow::{anyhow, bail, Result};
+use cargo_metadata::Message;
+use clap::{Parser, Subcommand, ValueEnum};
+use serde_json::json;
+use strum::Display;
+use xmas_elf::ElfFile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Display, ValueEnum)]
+#[strum(serialize_all = "lowercase")]
+enum Chip {
+    Esp32,
+    Esp32c2,
+    Esp32c3,
+    Esp32s2,
+    Esp32s3,
+}
+
+impl Chip {
+    pub fn toolchain(&self) -> &'static str {
+        match self {
+            Chip::Esp32c2 | Chip::Esp32c3 => "+nightly",
+            Chip::Esp32 | Chip::Esp32s2 | Chip::Esp32s3 => "+esp",
+        }
+    }
+
+    pub fn target(&self) -> &'static str {
+        match self {
+            Chip::Esp32 => "xtensa-esp32-none-elf",
+            Chip::Esp32c2 | Chip::Esp32c3 => "riscv32imc-unknown-none-elf",
+            Chip::Esp32s2 => "xtensa-esp32s2-none-elf",
+            Chip::Esp32s3 => "xtensa-esp32s3-none-elf",
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Build the flasher stub for the specified chip(s)
+    Build {
+        #[clap(value_enum)]
+        chips: Vec<Chip>,
+    },
+
+    /// Build the flasher stub for the specified chip(s) and convert it to JSON
+    Wrap {
+        #[clap(value_enum)]
+        chips: Vec<Chip>,
+    },
+}
+
+fn main() -> Result<()> {
+    env_logger::Builder::new()
+        .filter_module("xtask", log::LevelFilter::Info)
+        .init();
+
+    // The directory containing the cargo manifest for the 'xtask' package is a
+    // subdirectory within the cargo workspace.
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = workspace.parent().unwrap().canonicalize()?;
+
+    match Cli::parse().command {
+        Commands::Build { chips } => chips
+            .iter()
+            .try_for_each(|chip| build(&workspace, chip).map(|_| ())),
+        Commands::Wrap { chips } => chips.iter().try_for_each(|chip| wrap(&workspace, chip)),
+    }
+}
+
+fn build(workspace: &Path, chip: &Chip) -> Result<PathBuf> {
+    // Invoke the 'cargo build' command, passing our list of arguments.
+    let output = Command::new("cargo")
+        .args([
+            &format!("{}", chip.toolchain()),
+            "build",
+            "-Zbuild-std=core",
+            "--release",
+            &format!("--target={}", chip.target()),
+            &format!("--features={chip}"),
+        ])
+        .args(["--message-format", "json-diagnostic-rendered-ansi"])
+        .current_dir(workspace)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?
+        .wait_with_output()?;
+
+    // Parse build output.
+    let messages = Message::parse_stream(&output.stdout[..]);
+
+    // Find target artifact.
+    let mut target_artifact = None;
+
+    for message in messages {
+        let message = message?;
+
+        match message {
+            Message::CompilerArtifact(artifact) => {
+                if artifact.executable.is_some() {
+                    if target_artifact.is_some() {
+                        bail!("Multiple build artifacts found!");
+                    } else {
+                        target_artifact = Some(artifact);
+                    }
+                }
+            }
+            Message::CompilerMessage(message) => {
+                if let Some(rendered) = message.message.rendered {
+                    print!("{}", rendered);
+                }
+            }
+            // Ignore all other messages.
+            _ => (),
+        }
+    }
+
+    // Check if the command succeeded, otherwise return an error. Any error messages
+    // occurring during the build are shown above, when the compiler messages are
+    // rendered.
+    if !output.status.success() {
+        exit_with_process_status(output.status);
+    }
+
+    // If no target artifact was found, we don't have a path to return.
+    let target_artifact = target_artifact.ok_or(anyhow!("No build artifact found!"))?;
+    let artifact_path: PathBuf = target_artifact.executable.unwrap().into();
+
+    log::info!("{}", artifact_path.display());
+    Ok(artifact_path)
+}
+
+fn wrap(workspace: &Path, chip: &Chip) -> Result<()> {
+    let artifact_path = build(workspace, chip)?;
+
+    let elf_data = fs::read(artifact_path)?;
+    let elf = ElfFile::new(&elf_data).unwrap();
+
+    let entry = elf.header.pt2.entry_point();
+
+    let text_section = elf.find_section_by_name(".text").unwrap();
+    let mut text = text_section.raw_data(&elf).to_vec();
+    let text_start = text_section.address();
+
+    if text.len() % 4 != 0 {
+        text.extend(iter::repeat('\0' as u8).take(4 - (text.len() % 4)));
+    }
+
+    let data_section = elf.find_section_by_name(".data").unwrap();
+    let data = data_section.raw_data(&elf).to_vec();
+    let data_start = data_section.address();
+
+    let stub = json!({
+        "entry": entry,
+        "text": text,
+        "text_start": text_start,
+        "data": data,
+        "data_start": data_start,
+    });
+
+    let stub_file = workspace.join(format!("{chip}.json"));
+    let contents = serde_json::to_string(&stub)?;
+    fs::write(stub_file, contents)?;
+
+    Ok(())
+}
+
+fn exit_with_process_status(status: ExitStatus) -> ! {
+    #[cfg(unix)]
+    let code = {
+        use std::os::unix::process::ExitStatusExt;
+        let code = status.code().or_else(|| status.signal()).unwrap_or(1);
+
+        code
+    };
+
+    #[cfg(not(unix))]
+    let code = status.code().unwrap_or(1);
+
+    exit(code)
+}


### PR DESCRIPTION
The `xtask` package has two subcommands: _build_ and _wrap_, which allow you to build the stub for a given chip and subsequently convert it to JSON format. This completes one task outlined in #17.

I've also updated the CI workflow, mostly to prepare for the addition of the ESP32-C6 and ESP32-H2. Additionally I have added a release workflow to automatically generate and upload the JSON stubs whenever a release is created.

I've also updated the README a bit.

Even though CI is green, I've noticed that building for the ESP32-S2 results in a linker error; this is the case in `main` as well. I know @MabezDev was working on updating the stubs, so hopefully this resolves itself with that PR whenever it lands. Maybe we should `cargo build` instead of `cargo check` in CI to test for this in the future.