### PR TITLE
b64 encode text and data sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1437,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64",
  "cargo_metadata",
  "clap",
  "env_logger",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,4 @@ log            = "0.4.19"
 serde_json     = "1.0.100"
 strum          = { version = "0.25.0", features = ["derive"] }
 xmas-elf       = "0.9.0"
+base64 = "0.21.2"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,6 +142,8 @@ fn build(workspace: &Path, chip: &Chip) -> Result<PathBuf> {
 }
 
 fn wrap(workspace: &Path, chip: &Chip) -> Result<()> {
+    use base64::engine::{general_purpose, Engine};
+
     let artifact_path = build(workspace, chip)?;
 
     let elf_data = fs::read(artifact_path)?;
@@ -156,9 +158,11 @@ fn wrap(workspace: &Path, chip: &Chip) -> Result<()> {
     if text.len() % 4 != 0 {
         text.extend(iter::repeat('\0' as u8).take(4 - (text.len() % 4)));
     }
+    let text = general_purpose::STANDARD.encode(&text);
 
     let data_section = elf.find_section_by_name(".data").unwrap();
     let data = data_section.raw_data(&elf).to_vec();
+    let data = general_purpose::STANDARD.encode(&data);
     let data_start = data_section.address();
 
     let stub = json!({


### PR DESCRIPTION
Instead of an json array of bytes, the stub json files now contain a base64 encoded version of the various sections.