### PR TITLE
Fix the stub, FlashDeflateEnd was incorrectly sized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,17 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-backtrace"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834d20d58dc6baaf063924cb3ffa0b7f6388a593bae310c9f228c4bd47f0dde"
-dependencies = [
- "esp-println",
- "riscv 0.10.0",
- "xtensa-lx-rt",
-]
-
-[[package]]
 name = "esp-hal-common"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,12 +443,6 @@ dependencies = [
  "quote",
  "syn 1.0.107",
 ]
-
-[[package]]
-name = "esp-println"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcfe5d532cf2029b11996cab6b4af948f41c24b131c76422115634711549aaa"
 
 [[package]]
 name = "esp-synopsys-usb-otg"
@@ -604,7 +587,6 @@ version = "0.1.0"
 dependencies = [
  "assert2",
  "critical-section",
- "esp-backtrace",
  "esp32-hal",
  "esp32c2-hal",
  "esp32c3-hal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ exclude = [".github/", "esptool.patch"]
 
 [dependencies]
 critical-section  = "1.1.1"
-esp-backtrace = { version = "0.4.0", optional = true, features = ["exception-handler", "panic-handler", "print-uart"] }
 esp32-hal = { version = "0.7.0", optional = true }
 esp32c2-hal = { version = "0.2.0", optional = true }
 esp32c3-hal = { version = "0.4.0", optional = true }
@@ -33,11 +32,11 @@ mockall = "0.11.3"
 mockall_double = "0.3.0"
 
 [features]
-esp32 = ["esp32-hal", "esp-backtrace/esp32"]
-esp32s2 = ["esp32s2-hal", "esp-backtrace/esp32s2"]
-esp32s3 = ["esp32s3-hal", "esp-backtrace/esp32s3"]
-esp32c3 = ["esp32c3-hal", "esp-backtrace/esp32c3"]
-esp32c2 = ["esp32c2-hal", "esp-backtrace/esp32c2"]
+esp32 = ["esp32-hal"] 
+esp32s2 = ["esp32s2-hal"]
+esp32s3 = ["esp32s3-hal"]
+esp32c3 = ["esp32c3-hal"]
+esp32c2 = ["esp32c2-hal"]
 dprint = []
 
 [profile.release]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,7 +89,7 @@ pub struct DataCommand {
 #[repr(C, packed(1))]
 pub struct EndFlashCommand {
     pub base: CommandBase,
-    pub run_user_code: u32,
+    pub reboot: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,6 +221,7 @@ impl<'a> Response<'a> {
     }
 
     pub fn error(&mut self, error: Error) {
+        crate::dprintln!("Error: {:?}", error);
         self.status = 1;
         self.error = error as u8;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 
-use esp_backtrace as _;
 #[cfg(feature = "dprint")]
 use flasher_stub::hal::serial::{
     config::{Config, DataBits, Parity, StopBits},
@@ -81,4 +80,10 @@ fn main() -> ! {
         let data = stub.read_command(&mut buffer);
         stub.process_command(data);
     }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    flasher_stub::dprintln!("STUB Panic: {:?}", _info);
+    loop {}
 }

--- a/src/miniz_types.rs
+++ b/src/miniz_types.rs
@@ -1,3 +1,5 @@
+#![allow(non_camel_case_types)]
+
 const TINFL_MAX_HUFF_TABLES: usize = 3;
 const TINFL_MAX_HUFF_SYMBOLS_0: usize = 288;
 const TINFL_MAX_HUFF_SYMBOLS_1: usize = 32;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -163,7 +163,7 @@ impl<'a> Stub<'a> {
 
         self.in_flash_mode = false;
 
-        if cmd.run_user_code == 1 {
+        if cmd.reboot {
             self.send_response(response);
             self.target.delay_us(10_000);
             self.target.soft_reset();


### PR DESCRIPTION
I also removed `esp-backtrace` in favor of a custom panic, because it would print to UART0 which is useless for the stub.