### PR TITLE
Transport detection & Usb serial jtag support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           [
             { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
             { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c6", target: "riscv32imac-unknown-none-elf" },
+            { chip: "esp32h2", target: "riscv32imac-unknown-none-elf" },
           ]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,9 +441,10 @@ dependencies = [
 [[package]]
 name = "esp-hal-common"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "basic-toml",
+ "bitfield",
  "bitflags 2.3.3",
  "cfg-if",
  "critical-section",
@@ -470,7 +477,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.6.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -483,7 +490,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.3.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "riscv",
  "riscv-rt-macros",
@@ -491,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "esp-synopsys-usb-otg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0879f2f008c0213b1a5959345e54afcbf1490c1591f5145a5e65bdff371b65af"
+checksum = "5cc6734e87e7b86858f7884649deae6bf634d1e6f5b2d078e457cf4d72c541ec"
 dependencies = [
  "critical-section",
  "embedded-hal",
@@ -504,8 +511,7 @@ dependencies = [
 [[package]]
 name = "esp32"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0a6cd6fdb2f8fd98e65d12c1ccc24d3410def1a8a9b660a64d15dfe70b6857"
+source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
 dependencies = [
  "critical-section",
  "vcell",
@@ -515,7 +521,7 @@ dependencies = [
 [[package]]
 name = "esp32-hal"
 version = "0.13.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -534,7 +540,7 @@ dependencies = [
 [[package]]
 name = "esp32c2-hal"
 version = "0.8.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -543,8 +549,7 @@ dependencies = [
 [[package]]
 name = "esp32c3"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae547e9a4524b34c2b302fd71c304f8b221bcd4eed4ef17c8bf53408baacad5f"
+source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
 dependencies = [
  "critical-section",
  "vcell",
@@ -553,7 +558,7 @@ dependencies = [
 [[package]]
 name = "esp32c3-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -563,8 +568,7 @@ dependencies = [
 [[package]]
 name = "esp32c6"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d73f86b582845ee79dcc441d2c616bc6688c5b24741409c544949ffe3c1d24"
+source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
 dependencies = [
  "critical-section",
  "vcell",
@@ -573,7 +577,7 @@ dependencies = [
 [[package]]
 name = "esp32c6-hal"
 version = "0.3.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -583,8 +587,7 @@ dependencies = [
 [[package]]
 name = "esp32h2"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feccdd689fa2945a2947029a944559dc41f3665e9af8d5faff1e232c5b866ab2"
+source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
 dependencies = [
  "critical-section",
  "vcell",
@@ -593,7 +596,7 @@ dependencies = [
 [[package]]
 name = "esp32h2-hal"
 version = "0.1.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -614,7 +617,7 @@ dependencies = [
 [[package]]
 name = "esp32s2-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -624,8 +627,7 @@ dependencies = [
 [[package]]
 name = "esp32s3"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f05672306ffd2f39665c7eaf4615fc1d26f4cebfd0ad51828f81e53377fec5c"
+source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
 dependencies = [
  "critical-section",
  "vcell",
@@ -635,7 +637,7 @@ dependencies = [
 [[package]]
 name = "esp32s3-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
+source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
 dependencies = [
  "bare-metal",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-common"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "basic-toml",
  "bitflags 2.3.3",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.6.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.3.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "riscv",
  "riscv-rt-macros",
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "esp32-hal"
 version = "0.13.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "esp32c2-hal"
 version = "0.8.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "esp32c3-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "esp32c6-hal"
 version = "0.3.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "esp32h2-hal"
 version = "0.1.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "esp32s2-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "esp32s3-hal"
 version = "0.10.0"
-source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#10731d641532f92f837a1c17f1a861c7bccba473"
+source = "git+https://github.com/MabezDev/esp-hal?branch=segment-alias#6ee7fb58c57c0790354c1a9cf1c2da473d226fb8"
 dependencies = [
  "bare-metal",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-common"
 version = "0.10.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.6.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.3.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "riscv",
  "riscv-rt-macros",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "esp32"
 version = "0.24.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "esp32-hal"
 version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -530,8 +530,7 @@ dependencies = [
 [[package]]
 name = "esp32c2"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9412ef5fe6197762a31a7d71bfdd8f28c296cd48cb556460e22a67b4be0a4d7e"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -540,7 +539,7 @@ dependencies = [
 [[package]]
 name = "esp32c2-hal"
 version = "0.8.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -549,7 +548,7 @@ dependencies = [
 [[package]]
 name = "esp32c3"
 version = "0.15.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -558,7 +557,7 @@ dependencies = [
 [[package]]
 name = "esp32c3-hal"
 version = "0.10.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -568,7 +567,7 @@ dependencies = [
 [[package]]
 name = "esp32c6"
 version = "0.5.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -577,7 +576,7 @@ dependencies = [
 [[package]]
 name = "esp32c6-hal"
 version = "0.3.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -587,7 +586,7 @@ dependencies = [
 [[package]]
 name = "esp32h2"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -596,7 +595,7 @@ dependencies = [
 [[package]]
 name = "esp32h2-hal"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -606,8 +605,7 @@ dependencies = [
 [[package]]
 name = "esp32s2"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ae1c3966bb419ea6aaeff3c8f623a91dae61519ed900ed345b66a0e94dd26a"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -617,7 +615,7 @@ dependencies = [
 [[package]]
 name = "esp32s2-hal"
 version = "0.10.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "embedded-hal",
  "esp-hal-common",
@@ -627,7 +625,7 @@ dependencies = [
 [[package]]
 name = "esp32s3"
 version = "0.19.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?rev=c72707e#c72707e8ca10851d39d2e93b6c0d35866731ea77"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=ce6d5b5#ce6d5b5641be55241e77cdb5915b2e3513c8a7a5"
 dependencies = [
  "critical-section",
  "vcell",
@@ -637,7 +635,7 @@ dependencies = [
 [[package]]
 name = "esp32s3-hal"
 version = "0.10.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=28ac202f1a6850e41d61b967ea5d6745fcb7220e#28ac202f1a6850e41d61b967ea5d6745fcb7220e"
+source = "git+https://github.com/esp-rs/esp-hal?rev=00fac71#00fac71b68ef0cb07b2d6af992b13826e43fa7cc"
 dependencies = [
  "bare-metal",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +660,7 @@ dependencies = [
  "md-5",
  "mockall",
  "mockall_double",
+ "static_cell",
 ]
 
 [[package]]
@@ -720,7 +730,7 @@ version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
- "atomic-polyfill",
+ "atomic-polyfill 0.1.11",
  "hash32",
  "rustc_version",
  "spin",
@@ -1208,6 +1218,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cd323fc21eb534f903ee78d781d622099f9716c5b408ed23bcf39f8f1651c0"
+dependencies = [
+ "atomic-polyfill 1.0.3",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ esp32s2-hal = { version = "0.10.0", optional = true, git = "https://github.com/M
 esp32s3-hal = { version = "0.10.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
 heapless = { version = "0.7.16", default-features = false }
 md-5 = { version = "0.10.5", default-features = false }
+static_cell = "1"
+
 
 [dev-dependencies]
 assert2 = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ exclude = [".github/", "esptool.patch"]
 
 [dependencies]
 critical-section  = "1.1.1"
-esp32-hal = { version = "0.13.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32c2-hal = { version = "0.8.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32c3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32c6-hal = { version = "0.3.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32h2-hal = { version = "0.1.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32s2-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
-esp32s3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32-hal = { version = "0.13.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32c2-hal = { version = "0.8.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32c3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32c6-hal = { version = "0.3.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32h2-hal = { version = "0.1.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32s2-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
+esp32s3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "00fac71" }
 heapless = { version = "0.7.16", default-features = false }
 md-5 = { version = "0.10.5", default-features = false }
 static_cell = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ exclude = [".github/", "esptool.patch"]
 
 [dependencies]
 critical-section  = "1.1.1"
-esp32-hal = { version = "0.13.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32c2-hal = { version = "0.8.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32c3-hal = { version = "0.10.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32c6-hal = { version = "0.3.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32h2-hal = { version = "0.1.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32s2-hal = { version = "0.10.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
-esp32s3-hal = { version = "0.10.0", optional = true, git = "https://github.com/MabezDev/esp-hal", branch = "segment-alias" }
+esp32-hal = { version = "0.13.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32c2-hal = { version = "0.8.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32c3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32c6-hal = { version = "0.3.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32h2-hal = { version = "0.1.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32s2-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
+esp32s3-hal = { version = "0.10.0", optional = true, git = "https://github.com/esp-rs/esp-hal", rev = "28ac202f1a6850e41d61b967ea5d6745fcb7220e" }
 heapless = { version = "0.7.16", default-features = false }
 md-5 = { version = "0.10.5", default-features = false }
 static_cell = "1"

--- a/ld/esp32_rom.x
+++ b/ld/esp32_rom.x
@@ -18,3 +18,4 @@ PROVIDE( ets_delay_us = 0x40008534 );
 PROVIDE( tinfl_decompress = 0x4005ef30 );
 PROVIDE( spi_read_status_high = 0x40062448 );
 PROVIDE( spi_write_status = 0x400622f0 );
+PROVIDE( esp_flasher_rom_get_uart = 0x40009598 );

--- a/ld/esp32c2_rom.x
+++ b/ld/esp32c2_rom.x
@@ -28,3 +28,4 @@ PROVIDE( mbedtls_md5_update_ret = 0x40002be8 );
 PROVIDE( mbedtls_md5_finish_ret = 0x40002bec );
 PROVIDE( mbedtls_internal_md5_process = 0x40002bf0 );
 PROVIDE( mbedtls_md5_ret = 0x40002bf4 );
+PROVIDE( esp_flasher_rom_get_uart = 0x400000a8 );

--- a/ld/esp32c3_rom.x
+++ b/ld/esp32c3_rom.x
@@ -20,3 +20,4 @@ PROVIDE( esp_rom_spiflash_write_encrypted_disable = 0x4000011c );
 PROVIDE( esp_rom_spiflash_write_encrypted = 0x40000110 );
 PROVIDE( spi_read_status_high = 0x4000015c );
 PROVIDE( spi_write_status = 0x40000160 );
+PROVIDE( esp_flasher_rom_get_uart = 0x400000b0 );

--- a/ld/esp32c6_rom.x
+++ b/ld/esp32c6_rom.x
@@ -15,8 +15,4 @@ PROVIDE( esp_rom_spiflash_attach = 0x400001dc );
 PROVIDE( esp_rom_spiflash_write_encrypted = 0x40000114 );
 PROVIDE( esp_rom_spiflash_write_enable = 0x4000015c );
 PROVIDE( esp_rom_spiflash_erase_area = 0x40000158 );
-
-/*
-PROVIDE( ets_efuse_get_spiconfig = 0x4000071c ); // TODO
-PROVIDE( get_security_info_proc = 0x4004b9da ); // TODO
-*/
+PROVIDE( esp_flasher_rom_get_uart = 0x400000b4 );

--- a/ld/esp32h2_rom.x
+++ b/ld/esp32h2_rom.x
@@ -15,3 +15,4 @@ PROVIDE( esp_rom_spiflash_attach = 0x400001d4 );
 PROVIDE( esp_rom_spiflash_write_encrypted = 0x4000010c );
 PROVIDE( esp_rom_spiflash_write_enable = 0x40000154 );
 PROVIDE( esp_rom_spiflash_erase_area = 0x40000150 );
+PROVIDE( esp_flasher_rom_get_uart = 0x400000b4 );

--- a/ld/esp32s2_rom.x
+++ b/ld/esp32s2_rom.x
@@ -21,3 +21,4 @@ PROVIDE( ets_delay_us = 0x4000d888 );
 PROVIDE( tinfl_decompress = 0x40003000 );
 PROVIDE( spi_read_status_high = 0x40016284 );
 PROVIDE( spi_write_status = 0x400162a4  );
+PROVIDE( esp_flasher_rom_get_uart = 0x40012f60 );

--- a/ld/esp32s3_rom.x
+++ b/ld/esp32s3_rom.x
@@ -21,3 +21,4 @@ PROVIDE( ets_delay_us = 0x40000600 );
 PROVIDE( tinfl_decompress = 0x40000828 );
 PROVIDE( spi_read_status_high = 0x40000abc );
 PROVIDE( spi_write_status = 0x40000ac8 );
+PROVIDE( esp_flasher_rom_get_uart = 0x4000075c );

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,8 @@
+use heapless::Deque;
+
+
+pub mod uart;
+
+const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;
+
+static mut RX_QUEUE: Deque<u8, RX_QUEUE_SIZE> = Deque::new();

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,6 +2,7 @@ use heapless::Deque;
 
 
 pub mod uart;
+pub mod usb_serial_jtag;
 
 const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,12 @@
 use heapless::Deque;
 
-
 pub mod uart;
+#[cfg(any(
+    feature = "esp32c3",
+    feature = "esp32s3",
+    feature = "esp32c6",
+    feature = "esp32h2"
+))]
 pub mod usb_serial_jtag;
 
 const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;

--- a/src/io/uart.rs
+++ b/src/io/uart.rs
@@ -1,13 +1,8 @@
-use heapless::Deque;
-
 use crate::{
     hal::{peripherals::UART0, prelude::*, uart::Instance, Uart},
     protocol::InputIO,
 };
-
-const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;
-
-static mut RX_QUEUE: Deque<u8, RX_QUEUE_SIZE> = Deque::new();
+use super::RX_QUEUE;
 
 impl<T: Instance> InputIO for Uart<'_, T> {
     fn recv(&mut self) -> u8 {

--- a/src/io/uart.rs
+++ b/src/io/uart.rs
@@ -1,8 +1,8 @@
+use super::RX_QUEUE;
 use crate::{
     hal::{peripherals::UART0, prelude::*, uart::Instance, Uart},
     protocol::InputIO,
 };
-use super::RX_QUEUE;
 
 impl<T: Instance> InputIO for Uart<'_, T> {
     fn recv(&mut self) -> u8 {

--- a/src/io/usb_serial_jtag.rs
+++ b/src/io/usb_serial_jtag.rs
@@ -1,0 +1,39 @@
+use super::RX_QUEUE;
+use crate::{
+    hal::{
+        prelude::*,
+        usb_serial_jtag::{Instance, UsbSerialJtag},
+    },
+    protocol::InputIO,
+};
+
+impl InputIO for UsbSerialJtag<'_> {
+    fn recv(&mut self) -> u8 {
+        unsafe { while critical_section::with(|_| RX_QUEUE.is_empty()) {} }
+        unsafe { critical_section::with(|_| RX_QUEUE.pop_front().unwrap()) }
+    }
+
+    fn send(&mut self, bytes: &[u8]) {
+        self.write_bytes(bytes).unwrap()
+    }
+}
+
+#[interrupt]
+unsafe fn USB_SERIAL_JTAG() {
+    crate::dprintln!("USB_DEVICE Interrupt!");
+    let usj = crate::hal::peripherals::USB_DEVICE::steal();
+    let reg_block = usj.register_block();
+
+    while reg_block
+        .ep1_conf
+        .read()
+        .serial_out_ep_data_avail()
+        .bit_is_set()
+    {
+        unsafe { RX_QUEUE.push_back(reg_block.ep1.read().rdwr_byte().bits()).unwrap() };
+    }
+
+    reg_block
+            .int_clr
+            .write(|w| w.serial_out_recv_pkt_int_clr().set_bit());
+}

--- a/src/io/usb_serial_jtag.rs
+++ b/src/io/usb_serial_jtag.rs
@@ -18,25 +18,8 @@ impl InputIO for UsbSerialJtag<'_> {
     }
 }
 
-#[cfg(feature = "esp32c3")]
-#[interrupt]
-unsafe fn USB_SERIAL_JTAG() {
-    isr();
-}
-
-#[cfg(any(feature = "esp32c6", feature = "esp32h2"))]
-#[interrupt]
-unsafe fn USB() {
-    isr();
-}
-
-#[cfg(feature = "esp32s3")]
 #[interrupt]
 unsafe fn USB_DEVICE() {
-    isr();
-}
-
-unsafe fn isr() {
     let usj = crate::hal::peripherals::USB_DEVICE::steal();
     let reg_block = usj.register_block();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,12 @@ pub mod targets;
 #[derive(Debug)]
 pub enum TransportMethod {
     Uart,
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32c6", feature = "esp32h2"))]
+    #[cfg(any(
+        feature = "esp32c3",
+        feature = "esp32s3",
+        feature = "esp32c6",
+        feature = "esp32h2"
+    ))]
     UsbSerialJtag,
     #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
     UsbOtg,
@@ -67,9 +72,9 @@ pub fn detect_transport() -> TransportMethod {
     extern "C" {
         fn esp_flasher_rom_get_uart() -> *const Uart;
     }
-    #[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32c2"))]
+    #[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32h2"))]
     const USB_SERIAL_JTAG: u8 = 3;
-    #[cfg(any(feature = "esp32s3", feature = "esp32c6", feature = "esp32c2"))]
+    #[cfg(any(feature = "esp32s3"))]
     const USB_SERIAL_JTAG: u8 = 4;
 
     #[cfg(feature = "esp32s3")]
@@ -80,7 +85,12 @@ pub fn detect_transport() -> TransportMethod {
     let device = unsafe { esp_flasher_rom_get_uart() };
     let num = unsafe { (*device).buff_uart_no };
     match num {
-        #[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32c6", feature = "esp32h2"))]
+        #[cfg(any(
+            feature = "esp32c3",
+            feature = "esp32s3",
+            feature = "esp32c6",
+            feature = "esp32h2"
+        ))]
         USB_SERIAL_JTAG => TransportMethod::UsbSerialJtag,
         #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
         USB_OTG => TransportMethod::UsbOtg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,52 @@ pub use targets::Esp32s3 as target;
 
 pub mod commands;
 pub mod dprint;
+pub mod io;
 pub mod miniz_types;
 pub mod protocol;
-pub mod serial_io;
 pub mod targets;
+
+#[derive(Debug)]
+pub enum TransportMethod {
+    Uart,
+    UsbSerialJtag,
+    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+    UsbOtg,
+}
+
+pub fn detect_transport() -> TransportMethod {
+    #[repr(C)]
+    struct Uart {
+        baud_rate: u32,
+        data_bits: u32,
+        exist_parity: u32,
+        parity: u32,
+        stop_bits: u32,
+        flow_ctrl: u32,
+        buff_uart_no: u8,
+        rcv_buff: [u32; 2], // PAD
+        rcv_state: u32,
+        received: u32,
+    }
+    extern "C" {
+        fn esp_flasher_rom_get_uart() -> *const Uart;
+    }
+    #[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32c2"))]
+    const USB_SERIAL_JTAG: u8 = 3;
+    #[cfg(any(feature = "esp32s3", feature = "esp32c6", feature = "esp32c2"))]
+    const USB_SERIAL_JTAG: u8 = 4;
+
+    #[cfg(feature = "esp32s3")]
+    const USB_OTG: u8 = 3;
+    #[cfg(feature = "esp32s2")]
+    const USB_OTG: u8 = 2;
+
+    let device = unsafe { esp_flasher_rom_get_uart() };
+    let num = unsafe { (*device).buff_uart_no };
+    match num {
+        USB_SERIAL_JTAG => TransportMethod::UsbSerialJtag,
+        #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+        USB_OTG => TransportMethod::UsbOtg,
+        _ => TransportMethod::Uart,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod targets;
 #[derive(Debug)]
 pub enum TransportMethod {
     Uart,
+    #[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32c6", feature = "esp32h2"))]
     UsbSerialJtag,
     #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
     UsbOtg,
@@ -79,6 +80,7 @@ pub fn detect_transport() -> TransportMethod {
     let device = unsafe { esp_flasher_rom_get_uart() };
     let num = unsafe { (*device).buff_uart_no };
     match num {
+        #[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32c6", feature = "esp32h2"))]
         USB_SERIAL_JTAG => TransportMethod::UsbSerialJtag,
         #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
         USB_OTG => TransportMethod::UsbOtg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,11 +114,6 @@ fn main() -> ! {
             );
             usb_serial.listen_rx_packet_recv_interrupt();
             interrupt::enable(
-                #[cfg(feature = "esp32c3")]
-                peripherals::Interrupt::USB_SERIAL_JTAG,
-                #[cfg(any(feature = "esp32c6", feature = "esp32h2"))]
-                peripherals::Interrupt::USB,
-                #[cfg(feature = "esp32s3")]
                 peripherals::Interrupt::USB_DEVICE,
                 interrupt::Priority::Priority1,
             )

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -92,7 +92,7 @@ fn build(workspace: &Path, chip: &Chip) -> Result<PathBuf> {
             "-Zbuild-std-features=panic_immediate_abort",
             "--release",
             &format!("--target={}", chip.target()),
-            &format!("--features={chip},dprint"),
+            &format!("--features={chip}"),
         ])
         .args(["--message-format", "json-diagnostic-rendered-ansi"])
         .current_dir(workspace)
@@ -238,7 +238,7 @@ fn concat_sections(elf: &ElfFile, list: &[&str]) -> (u64, Vec<u8>) {
             let end = section.address() as usize + data_data.len();
             let padding = next.address() as usize - end;
             log::debug!("Size of padding to next section: {}", padding);
-            if padding > 1024 {
+            if padding > 512 {
                 log::warn!("Padding to next section seems large ({}bytes), are the correct linker sections being used? Current: 0x{:08X}, Next: 0x{:08X}", padding, section.address(), next.address());
             }
             padding

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -92,7 +92,7 @@ fn build(workspace: &Path, chip: &Chip) -> Result<PathBuf> {
             "-Zbuild-std-features=panic_immediate_abort",
             "--release",
             &format!("--target={}", chip.target()),
-            &format!("--features={chip}"),
+            &format!("--features={chip},dprint"),
         ])
         .args(["--message-format", "json-diagnostic-rendered-ansi"])
         .current_dir(workspace)


### PR DESCRIPTION
This PR adds transport detection and a `InputIO` implementation for the USB-SERIAL-JTAG driver.

Currently, draft because the usb serial jtag interrupt is not firing on the esp32s3 see https://github.com/esp-rs/esp-hal/issues/633.