### PR TITLE
Remove usage of dyn, instead use an enum for runtime dispatch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,4 +88,19 @@ fn main() {
         println!("cargo:rerun-if-changed=ld/ld/esp32s3_rom.x");
         println!("cargo:rustc-link-arg=-Tld/esp32s3_rom.x");
     }
+
+    emit_cfg();
+}
+
+fn emit_cfg() {
+    #[cfg(any(
+        feature = "esp32c3",
+        feature = "esp32s3",
+        feature = "esp32c6",
+        feature = "esp32h2"
+    ))]
+    println!("cargo:rustc-cfg=usb_device");
+
+    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+    println!("cargo:rustc-cfg=usb0");
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,64 +5,69 @@ use heapless::Deque;
 use crate::protocol::InputIO;
 
 pub mod uart;
-#[cfg(any(
-    feature = "esp32c3",
-    feature = "esp32s3",
-    feature = "esp32c6",
-    feature = "esp32h2"
-))]
+#[cfg(usb_device)]
 pub mod usb_serial_jtag;
 
 const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;
 
 static mut RX_QUEUE: Deque<u8, RX_QUEUE_SIZE> = Deque::new();
 
+trait UartMarker: InputIO {}
+trait UsbSerialJtagMarker: InputIO {}
+trait UsbOtgMarker: InputIO {}
+
 #[non_exhaustive]
-pub enum Transport<S, J> {
+pub enum Transport<S, J, U> {
     Uart(S),
-    #[cfg(any(
-        feature = "esp32c3",
-        feature = "esp32s3",
-        feature = "esp32c6",
-        feature = "esp32h2"
-    ))]
+    #[cfg(usb_device)]
     UsbSerialJtag(J),
-    // #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    // UsbOtg(U),
-    #[doc(hidden)] // a type to "use" the generic params
-    __Hidden(PhantomData<S>, PhantomData<J> /* , PhantomData<U> */),
+    #[cfg(usb0)]
+    UsbOtg(U),
+    #[doc(hidden)]
+    __Hidden(PhantomData<J>, PhantomData<U>),
 }
 
-impl<S, J> InputIO for Transport<S, J>
+impl<S, J, U> InputIO for Transport<S, J, U>
 where
-    S: InputIO,
-    J: InputIO,
+    S: UartMarker,
+    J: UsbSerialJtagMarker,
+    U: UsbOtgMarker,
 {
     fn recv(&mut self) -> u8 {
         match self {
             Transport::Uart(s) => s.recv(),
-            #[cfg(any(
-                feature = "esp32c3",
-                feature = "esp32s3",
-                feature = "esp32c6",
-                feature = "esp32h2"
-            ))]
+            #[cfg(usb_device)]
             Transport::UsbSerialJtag(j) => j.recv(),
-            _ => unreachable!(),
+            _ => todo!(),
         }
     }
 
     fn send(&mut self, data: &[u8]) {
         match self {
             Transport::Uart(s) => s.send(data),
-            #[cfg(any(
-                feature = "esp32c3",
-                feature = "esp32s3",
-                feature = "esp32c6",
-                feature = "esp32h2"
-            ))]
+            #[cfg(usb_device)]
             Transport::UsbSerialJtag(j) => j.send(data),
-            _ => unreachable!(),
+            _ => todo!(),
         }
     }
 }
+
+pub struct Noop;
+
+impl InputIO for Noop {
+    fn recv(&mut self) -> u8 {
+        todo!()
+    }
+
+    fn send(&mut self, _data: &[u8]) {
+        todo!()
+    }
+}
+
+impl UartMarker for Noop {}
+impl UsbSerialJtagMarker for Noop {}
+impl UsbOtgMarker for Noop {}
+
+impl<T: UartMarker> UartMarker for &mut T {}
+impl<T: UsbSerialJtagMarker> UsbSerialJtagMarker for &mut T {}
+impl<T: UsbOtgMarker> UsbOtgMarker for &mut T {}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,8 @@
+use core::marker::PhantomData;
+
 use heapless::Deque;
+
+use crate::protocol::InputIO;
 
 pub mod uart;
 #[cfg(any(
@@ -12,3 +16,53 @@ pub mod usb_serial_jtag;
 const RX_QUEUE_SIZE: usize = crate::targets::MAX_WRITE_BLOCK + 0x400;
 
 static mut RX_QUEUE: Deque<u8, RX_QUEUE_SIZE> = Deque::new();
+
+#[non_exhaustive]
+pub enum Transport<S, J> {
+    Uart(S),
+    #[cfg(any(
+        feature = "esp32c3",
+        feature = "esp32s3",
+        feature = "esp32c6",
+        feature = "esp32h2"
+    ))]
+    UsbSerialJtag(J),
+    // #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+    // UsbOtg(U),
+    #[doc(hidden)] // a type to "use" the generic params
+    __Hidden(PhantomData<S>, PhantomData<J> /* , PhantomData<U> */),
+}
+
+impl<S, J> InputIO for Transport<S, J>
+where
+    S: InputIO,
+    J: InputIO,
+{
+    fn recv(&mut self) -> u8 {
+        match self {
+            Transport::Uart(s) => s.recv(),
+            #[cfg(any(
+                feature = "esp32c3",
+                feature = "esp32s3",
+                feature = "esp32c6",
+                feature = "esp32h2"
+            ))]
+            Transport::UsbSerialJtag(j) => j.recv(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn send(&mut self, data: &[u8]) {
+        match self {
+            Transport::Uart(s) => s.send(data),
+            #[cfg(any(
+                feature = "esp32c3",
+                feature = "esp32s3",
+                feature = "esp32c6",
+                feature = "esp32h2"
+            ))]
+            Transport::UsbSerialJtag(j) => j.send(data),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/io/uart.rs
+++ b/src/io/uart.rs
@@ -1,4 +1,4 @@
-use super::RX_QUEUE;
+use super::{UartMarker, RX_QUEUE};
 use crate::{
     hal::{peripherals::UART0, prelude::*, uart::Instance, Uart},
     protocol::InputIO,
@@ -15,6 +15,8 @@ impl<T: Instance> InputIO for Uart<'_, T> {
     }
 }
 
+impl<T: Instance> UartMarker for Uart<'_, T> {}
+
 #[interrupt]
 fn UART0() {
     let uart = unsafe { &*UART0::ptr() };
@@ -30,7 +32,7 @@ fn UART0() {
         // the read _must_ be a word read so the hardware correctly detects the read and
         // pops the byte from the fifo cast the result to a u8, as only the
         // first byte contains the data
-        let data = unsafe { (uart.fifo.as_ptr() as *mut u32).offset(offset).read() } as u8;
+        let data = unsafe { uart.fifo.as_ptr().offset(offset).read() } as u8;
         unsafe { RX_QUEUE.push_back(data).unwrap() };
     }
 

--- a/src/io/usb_serial_jtag.rs
+++ b/src/io/usb_serial_jtag.rs
@@ -1,4 +1,4 @@
-use super::RX_QUEUE;
+use super::{UsbSerialJtagMarker, RX_QUEUE};
 use crate::{
     hal::{
         prelude::*,
@@ -17,6 +17,8 @@ impl InputIO for UsbSerialJtag<'_> {
         self.write_bytes(bytes).unwrap()
     }
 }
+
+impl UsbSerialJtagMarker for UsbSerialJtag<'_> {}
 
 #[interrupt]
 unsafe fn USB_DEVICE() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,20 +40,7 @@ pub struct Stub<T> {
     decompressor: tinfl_decompressor,
     last_error: Option<Error>,
     in_flash_mode: bool,
-    #[cfg(feature = "esp32c3")]
-    target: crate::targets::Esp32c3,
-    #[cfg(feature = "esp32c6")]
-    target: crate::targets::Esp32c6,
-    #[cfg(feature = "esp32h2")]
-    target: crate::targets::Esp32h2,
-    #[cfg(feature = "esp32c2")]
-    target: crate::targets::Esp32c2,
-    #[cfg(feature = "esp32")]
-    target: crate::targets::Esp32,
-    #[cfg(feature = "esp32s3")]
-    target: crate::targets::Esp32s3,
-    #[cfg(feature = "esp32s2")]
-    target: crate::targets::Esp32s2,
+    target: crate::target,
 }
 
 fn slice_to_struct<T: Sized + Copy>(slice: &[u8]) -> Result<T, Error> {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -399,3 +399,28 @@ impl EspCommon for Esp32c3 {}
 impl EspCommon for Esp32c2 {}
 impl EspCommon for Esp32c6 {}
 impl EspCommon for Esp32h2 {}
+
+pub trait EspUsbSerialJtagId {
+    /// The ID returned for USB_SERIAL_JTAG from `esp_flasher_rom_get_uart`
+    const USB_SERIAL_JTAG_ID: u8 = 3; // default for most chips is 3
+}
+
+impl EspUsbSerialJtagId for Esp32c3 {}
+impl EspUsbSerialJtagId for Esp32c6 {}
+impl EspUsbSerialJtagId for Esp32h2 {}
+impl EspUsbSerialJtagId for Esp32s3 {
+    const USB_SERIAL_JTAG_ID: u8 = 4;
+}
+
+pub trait EspUsbOtgId {
+    /// The ID returned for USB_OTG from `esp_flasher_rom_get_uart`
+    const USB_OTG_ID: u8;
+}
+
+impl EspUsbOtgId for Esp32s2 {
+    const USB_OTG_ID: u8 = 2;
+}
+
+impl EspUsbOtgId for Esp32s3 {
+    const USB_OTG_ID: u8 = 3;
+}


### PR DESCRIPTION
Closes #22 

Didn't really make much of an impact on binary size, saved around 60bytes, but maybe using an enum will give the compiler a more clear view and enable better optimizations.