### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.build.target }}
@@ -62,7 +62,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
@@ -89,7 +89,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.build.target }}
@@ -113,7 +113,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
@@ -154,7 +154,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.build.target }}
@@ -177,7 +177,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: build & wrap (${{ matrix.build.chip }})
+        working-directory: xtask
         run: cargo xtask wrap ${{ matrix.build.chip }}
       - uses: svenstaro/upload-release-action@v2
         with:
@@ -70,6 +71,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: build & wrap (${{ matrix.build.chip }})
+        working-directory: xtask
         run: cargo xtask wrap ${{ matrix.build.chip }}
       - uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: build & wrap (${{ matrix.build.chip }})
         working-directory: xtask
-        run: cargo xtask wrap ${{ matrix.build.chip }}
+        run: cargo run -- wrap ${{ matrix.build.chip }}
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ env.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: build & wrap (${{ matrix.build.chip }})
         working-directory: xtask
-        run: cargo xtask wrap ${{ matrix.build.chip }}
+        run: cargo run -- wrap ${{ matrix.build.chip }}
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,46 +9,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  # --------------------------------------------------------------------------
-  # Release (RISC-V)
-
-  release-riscv:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        build:
-          [
-            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
-            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
-            { chip: "esp32c6", target: "riscv32imac-unknown-none-elf" },
-            { chip: "esp32h2", target: "riscv32imac-unknown-none-elf" },
-          ]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: ${{ matrix.build.target }}
-          toolchain: nightly
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
-
-      - name: build & wrap (${{ matrix.build.chip }})
-        working-directory: xtask
-        run: cargo run -- wrap ${{ matrix.build.chip }}
-      - uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ env.GITHUB_TOKEN }}
-          file: "${{ matrix.build.chip }}.*"
-          file_glob: true
-          tag: ${{ github.ref }}
-
-  # --------------------------------------------------------------------------
-  # Release (Xtensa)
-
-  release-xtensa:
+  release:
     runs-on: ubuntu-latest
 
     strategy:
@@ -57,13 +18,26 @@ jobs:
         build:
           [
             { chip: "esp32", target: "xtensa-esp32-none-elf" },
+            { chip: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+            { chip: "esp32c6", target: "riscv32imac-unknown-none-elf" },
+            { chip: "esp32h2", target: "riscv32imac-unknown-none-elf" },
             { chip: "esp32s2", target: "xtensa-esp32s2-none-elf" },
             { chip: "esp32s3", target: "xtensa-esp32s3-none-elf" },
           ]
 
     steps:
       - uses: actions/checkout@v4
+      # RISC-V toolchain
+      - uses: dtolnay/rust-toolchain@v1
+        if: matrix.build.chip != 'esp32' && matrix.build.chip != 'esp32s2' && matrix.build.chip != 'esp32s3'
+        with:
+          target: ${{ matrix.build.target }}
+          toolchain: nightly
+          components: rust-src
+      # Xtensa toolchain
       - uses: esp-rs/xtensa-toolchain@v1.5
+        if: matrix.build.chip == 'esp32' || matrix.build.chip == 'esp32s2' || matrix.build.chip == 'esp32s3'
         with:
           default: true
           ldproxy: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.build.target }}
@@ -61,7 +61,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,8 @@ jobs:
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ env.GITHUB_TOKEN }}
-          file: "${{ matrix.build.chip }}.json"
+          file: "${{ matrix.build.chip }}.*"
+          file_glob: true
           tag: ${{ github.ref }}
 
   # --------------------------------------------------------------------------
@@ -73,5 +74,6 @@ jobs:
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ env.GITHUB_TOKEN }}
-          file: "${{ matrix.build.chip }}.json"
+          file: "${{ matrix.build.chip }}.*"
+          file_glob: true
           tag: ${{ github.ref }}


### PR DESCRIPTION
- Store resulting JSON and TOML files on the release
- Update `actions/checkout` version
- Adjust release workflow to work with `xtaks`  changes
- Merged Xtensa and RISC-V release jobs into a single one:
  - Happy to revert this change, it introduces two `if`s but reduces duplication.  
  
  Test releases:
  - [v0.2.0](https://github.com/SergioGasquez/esp-flasher-stub/actions/runs/7302134305): Before unifying the Xtensa and RISC-V jobs
  - [v0.2.1](https://github.com/SergioGasquez/esp-flasher-stub/actions/runs/7302218917): After unification.