### PR TITLE
Update ChangeBaudrate processing

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -446,9 +446,9 @@ impl<T: InputIO> Stub<T> {
             ChangeBaudrate => {
                 let baud: ChangeBaudrateCommand = slice_to_struct(payload)?;
                 self.send_response(response);
-                self.target.delay_us(10_000); // Wait for response to be transfered
+                self.target.delay_us(15_000); // Wait for response to be transfered
                 self.target.change_baudrate(baud.old, baud.new);
-                self.send_greeting();
+                self.target.delay_us(1_000);
                 response_sent = true;
             }
             EraseFlash => self.target.erase_flash()?,


### PR DESCRIPTION
Change the way we process ChangeBaudrate commands:
- Increased the delay after sending the response
- Remove sending the greeting: C stubs don't do this
- Added a small delay after changing the baudrate to imitate the [C stubs](https://github.com/espressif/esptool/blob/6c5cfd6dabcdc04397589dae160db88b866fd791/flasher_stub/stub_io.c#L310-L312)

PR is open against the `esp-hal-upgrade` branch which is the one I used for testing.