### PR TITLE
Use XtalClock as UART source and adapt interrupt binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,41 +10,42 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anyhow"
-version = "1.0.76"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "assert2"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf98d1183406dcb8f8b545e1f24829d75c1a9d35eec4b86309a22aa8b6d8e95"
+checksum = "844ca3172d927ddd9d01f63b6c80f4ebd3e01c3f787c204626635450dfe3edba"
 dependencies = [
  "assert2-macros",
+ "diff",
  "is-terminal",
  "yansi",
 ]
 
 [[package]]
 name = "assert2-macros"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c55bdf3e6f792f8f1c750bb6886b7ca40fa5a354ddb7a4dee550b93985a9235"
+checksum = "9ec0e42bd0fe1c8d72c7bde53ac8686764cea0fd86f412b92fcad20fea08b489"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -54,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bare-metal"
@@ -66,24 +67,24 @@ checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bitfield"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "byteorder"
@@ -112,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -146,7 +147,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -157,7 +158,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -170,6 +171,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "document-features"
@@ -185,12 +192,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embedded-can"
@@ -266,7 +267,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -276,29 +277,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "esp-build"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94a4b8d74e7cc7baabcca5b2277b41877e039ad9cd49959d48ef94dac7eab4b"
 dependencies = [
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
  "termcolor",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "0.16.1"
-source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e19440eb58fd1dd0c4f6722c953f7026571210c70ce69956d022faeb8fe4b4"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -330,7 +323,7 @@ dependencies = [
  "rand_core",
  "riscv",
  "serde",
- "strum 0.26.1",
+ "strum 0.26.2",
  "usb-device",
  "void",
  "xtensa-lx",
@@ -339,8 +332,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.9.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a9e9df075eb0c1e0a4349a4317c86b01be2acabe6f69d935c9c71d8a99e56a"
 dependencies = [
  "darling",
  "document-features",
@@ -350,24 +344,26 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "esp-metadata"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a97109e81e9fb68cbf838ffda09cebbc9b25fe12f8b8a5e1b32391561e7c153"
 dependencies = [
  "basic-toml",
  "lazy_static",
  "serde",
- "strum 0.26.1",
+ "strum 0.26.2",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.7.0"
-source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404129c79e9dc34f8b468ec44e71ce36a0bd443cb88be0feffa4b9f3856c97a6"
 dependencies = [
  "document-features",
  "riscv",
@@ -389,8 +385,9 @@ dependencies = [
 
 [[package]]
 name = "esp32"
-version = "0.29.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899e1a52a7ee96d95ac00a92b39c0d5cbe718018a0ab810adf3162afe6dad44b"
 dependencies = [
  "critical-section",
  "vcell",
@@ -399,8 +396,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c2"
-version = "0.18.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4657fc6a398be0790a52adc406e7deda4a07358cb1d1e88b16a93821b66c095a"
 dependencies = [
  "critical-section",
  "vcell",
@@ -408,8 +406,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c22d8c27e7d675ef79db212b9e41df80aef6db1a5c819e4e726735f64ee0700"
 dependencies = [
  "critical-section",
  "vcell",
@@ -417,8 +416,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.12.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb7fd83dcdaf1d904f789b2739b646134ec8346fdde2150b7903ef049d81d13"
 dependencies = [
  "critical-section",
  "vcell",
@@ -426,8 +426,9 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.8.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d95ed215385d138d8594567b2942c51b40a7a107b151539df15cce5eaebc84"
 dependencies = [
  "critical-section",
  "vcell",
@@ -435,8 +436,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s2"
-version = "0.20.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018ab2ca65f0d3f8723cddc60959adc4a648589950f5ed28cf18e3c10c38e262"
 dependencies = [
  "critical-section",
  "vcell",
@@ -445,8 +447,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.24.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd8d5ad8c9984fdb3f81de5a85e21a6499993c3bebab2585631139bbf36abbb"
 dependencies = [
  "critical-section",
  "vcell",
@@ -537,9 +540,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "ident_case"
@@ -549,9 +552,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -559,22 +562,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -585,15 +579,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "litrs"
@@ -622,24 +610,24 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "minijinja"
-version = "1.0.10"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208758577ef2c86cf5dd3e85730d161413ec3284e2d73b2ef65d9a24d9971bcb"
+checksum = "fb5c5e3d2b4c0a6832bd3d571f7c19a7c1c1f05f11a6e85ae1a29f76be5f9455"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -668,7 +656,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -680,7 +668,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -706,9 +694,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "object"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "flate2",
  "memchr",
@@ -732,12 +720,11 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
- "itertools",
  "predicates-core",
 ]
 
@@ -792,18 +779,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -828,9 +815,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -840,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -851,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "riscv"
@@ -886,23 +873,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ruzstd"
@@ -923,28 +897,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -991,11 +965,11 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.1",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -1013,15 +987,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1037,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1155,141 +1129,82 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -1327,7 +1242,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +225,16 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -267,10 +286,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-build"
+version = "0.1.0"
+source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+dependencies = [
+ "quote",
+ "syn 2.0.52",
+ "termcolor",
+]
+
+[[package]]
 name = "esp-hal"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e021610c11f106869f382f532fb81de0df98fd2b41299deba81bb62e9c4c4f8"
+version = "0.16.1"
+source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -278,10 +306,14 @@ dependencies = [
  "cfg-if",
  "critical-section",
  "document-features",
+ "embedded-can",
  "embedded-dma",
- "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
  "enumset",
+ "esp-build",
  "esp-hal-procmacros",
+ "esp-metadata",
  "esp-riscv-rt",
  "esp-synopsys-usb-otg",
  "esp32",
@@ -289,7 +321,6 @@ dependencies = [
  "esp32c3",
  "esp32c6",
  "esp32h2",
- "esp32p4",
  "esp32s2",
  "esp32s3",
  "fugit",
@@ -309,8 +340,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05084ecf8446fe60e0aff6c3873c96dca56dc383a449324ca555edbb80ae60c0"
+source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
 dependencies = [
  "darling",
  "document-features",
@@ -324,10 +354,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-metadata"
+version = "0.1.0"
+source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
+dependencies = [
+ "basic-toml",
+ "lazy_static",
+ "serde",
+ "strum 0.26.1",
+]
+
+[[package]]
 name = "esp-riscv-rt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e599762d31156fa2322db4d5a0784c13b6122b79c1fa7bed70953de2f7d731f1"
+source = "git+https://github.com/esp-rs/esp-hal?rev=8f2ee88#8f2ee88491e8b7292438c77e960a04b4f5f9ab14"
 dependencies = [
  "document-features",
  "riscv",
@@ -336,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "esp-synopsys-usb-otg"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380a853a04a2a534e3ce8e9fef0215a68d56f6386365bc9799a3bd1f24f8e9b7"
+checksum = "cea082d4a065ea923e074cbfda48e5fdf90aa13bdeba948be5a066cb029a9512"
 dependencies = [
  "critical-section",
  "embedded-hal 0.2.7",
@@ -350,8 +390,7 @@ dependencies = [
 [[package]]
 name = "esp32"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343ac30c4537d3f8526490db4264091a9785a55bcdfc22fc34482751a501d8d2"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -361,8 +400,7 @@ dependencies = [
 [[package]]
 name = "esp32c2"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e30c9147b7a1f388887dfd2fe7da4d6159a0248603674af5f3a5282a46cd11"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -371,8 +409,7 @@ dependencies = [
 [[package]]
 name = "esp32c3"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7ee710c1e4f16b5e840cdfec3f4e7642b7517a877c5c4b7e1cafa9a14117c5"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -381,8 +418,7 @@ dependencies = [
 [[package]]
 name = "esp32c6"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0275425ea3a7675b7b5903163a93b65e8ce5b9c8a7749ed397279ed2ade3e3"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -391,18 +427,7 @@ dependencies = [
 [[package]]
 name = "esp32h2"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606c8e60d3e68afda997fa9fcc8d8fe1d2e3c172505bb03eb9ab79b4bca4d6a"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32p4"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c0bc7973e6805e3c3c3c979e9418ba30380d8c16989a477440dbce8cf1965"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -411,8 +436,7 @@ dependencies = [
 [[package]]
 name = "esp32s2"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbcb8e9a4097fbf1c455fc776ad46a4bb7861d5bad3c3cd4549b666ad906ce4"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -422,8 +446,7 @@ dependencies = [
 [[package]]
 name = "esp32s3"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044e216560a33aa5d6c98163c8ae4278845ec3bae7b9cab520da0697be4f23a6"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=f6b5e6b#f6b5e6b3f37dbaa571a3f7e35d41b2a12d77bdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -1024,6 +1047,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1121,37 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ categories   = ["embedded", "no-std"]
 
 [dependencies]
 critical-section = "1.1.2"
-esp-hal = { version = "0.16.0" }
-heapless         = { version = "0.8.0",  default-features = false }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "8f2ee88" }
+heapless         = { version = "0.8.0", default-features = false }
 static_cell      = "2.0.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories   = ["embedded", "no-std"]
 
 [dependencies]
 critical-section = "1.1.2"
-esp-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "8f2ee88" }
+esp-hal          = "0.17.0"
 heapless         = { version = "0.8.0", default-features = false }
 static_cell      = "2.0.0"
 

--- a/src/io/uart.rs
+++ b/src/io/uart.rs
@@ -28,7 +28,7 @@ where
 impl<T> UartMarker for Uart<'_, T, Blocking> where T: Instance {}
 
 #[handler]
-pub fn uart0_hanlder() {
+pub fn uart0_handler() {
     let uart = unsafe { &*UART0::ptr() };
 
     while uart.status().read().rxfifo_cnt().bits() > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod targets;
 pub use esp_hal as hal;
 
 use self::{
-    hal::{peripherals::UART0, Uart},
+    hal::{peripherals::UART0, uart::Uart, Blocking},
     io::Noop,
 };
 
@@ -80,21 +80,21 @@ impl TransportMethod {
 // TODO this sucks, but default generic parameters are not used when inference
 // fails, meaning that we _have_ to specifiy the types here Seems like work on this has stalled: https://github.com/rust-lang/rust/issues/27336, note that I tried the feature and it didn't work.
 #[cfg(not(any(usb_device, usb0)))]
-pub type Transport = io::Transport<&'static mut Uart<'static, UART0>, Noop, Noop>;
+pub type Transport = io::Transport<&'static mut Uart<'static, UART0, Blocking>, Noop, Noop>;
 
 #[cfg(all(usb_device, not(usb0)))]
 pub type Transport = io::Transport<
-    &'static mut Uart<'static, UART0>,
-    &'static mut crate::hal::UsbSerialJtag<'static>,
+    &'static mut Uart<'static, UART0, Blocking>,
+    &'static mut crate::hal::usb_serial_jtag::UsbSerialJtag<'static, Blocking>,
     Noop,
 >;
 
 #[cfg(all(not(usb_device), usb0))]
-pub type Transport = io::Transport<&'static mut Uart<'static, UART0>, Noop, Noop>; // TODO replace Noop with usb type later
+pub type Transport = io::Transport<&'static mut Uart<'static, UART0, Blocking>, Noop, Noop>; // TODO replace Noop with usb type later
 
 #[cfg(all(usb_device, usb0))]
 pub type Transport = io::Transport<
-    &'static mut Uart<'static, UART0>,
-    &'static mut crate::hal::UsbSerialJtag<'static>,
+    &'static mut Uart<'static, UART0, Blocking>,
+    &'static mut crate::hal::usb_serial_jtag::UsbSerialJtag<'static, Blocking>,
     Noop, // TODO replace Noop with usb type later
 >;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,22 +2,22 @@
 #![no_std]
 
 #[cfg(feature = "dprint")]
-use flasher_stub::hal::{
-    gpio::IO,
-    uart::{
-        config::{Config, DataBits, Parity, StopBits},
-        TxRxPins,
-    },
-};
+use flasher_stub::hal::gpio::IO;
 use flasher_stub::{
     dprintln,
     hal::{
         clock::{ClockControl, Clocks},
         entry,
-        interrupt::{self, Priority},
-        peripherals::{self, Interrupt, Peripherals},
+        gpio,
+        peripherals::{self, Peripherals},
         prelude::*,
-        Uart,
+        uart::{
+            config::{Config, DataBits, Parity, StopBits},
+            ClockSource,
+            TxRxPins,
+            Uart,
+        },
+        Blocking,
     },
     protocol::Stub,
     targets,
@@ -49,17 +49,13 @@ fn main() -> ! {
     #[cfg(feature = "dprint")]
     let _ = Uart::new_with_config(
         peripherals.UART1,
-        Config {
-            baudrate: 115_200,
-            data_bits: DataBits::DataBits8,
-            parity: Parity::ParityNone,
-            stop_bits: StopBits::STOP1,
-        },
+        Config::default(),
         Some(TxRxPins::new_tx_rx(
             io.pins.gpio2.into_push_pull_output(),
             io.pins.gpio0.into_floating_input(),
         )),
         &clocks,
+        None,
     );
 
     // Detect the transport method being used, and configure/initialize the
@@ -97,11 +93,28 @@ fn main() -> ! {
 
 // Initialize the UART0 peripheral as the `Transport`.
 fn transport_uart(uart0: peripherals::UART0, clocks: &Clocks<'_>) -> Transport {
-    let mut serial = Uart::new(uart0, &clocks);
-    serial.listen_rx_fifo_full();
-    interrupt::enable(Interrupt::UART0, Priority::Priority1).unwrap();
+    let uart_config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        clock_source: ClockSource::Xtal,
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        clock_source: ClockSource::Apb,
+    };
 
-    static mut TRANSPORT: StaticCell<Uart<'static, peripherals::UART0>> = StaticCell::new();
+    let mut serial = Uart::new_with_config(
+        uart0,
+        uart_config,
+        None::<TxRxPins<gpio::NoPinType, gpio::NoPinType>>,
+        clocks,
+        Some(flasher_stub::io::uart::uart0_hanlder),
+    );
+    serial.listen_rx_fifo_full();
+
+    static mut TRANSPORT: StaticCell<Uart<'static, peripherals::UART0, Blocking>> =
+        StaticCell::new();
 
     Transport::Uart(unsafe { TRANSPORT.init(serial) })
 }
@@ -109,13 +122,15 @@ fn transport_uart(uart0: peripherals::UART0, clocks: &Clocks<'_>) -> Transport {
 // Initialize the USB Serial JTAG peripheral as the `Transport`.
 #[cfg(usb_device)]
 fn transport_usb_serial_jtag(usb_device: peripherals::USB_DEVICE) -> Transport {
-    use flasher_stub::hal::UsbSerialJtag;
+    use flasher_stub::hal::usb_serial_jtag::UsbSerialJtag;
 
-    let mut usb_serial = UsbSerialJtag::new(usb_device);
+    let mut usb_serial = UsbSerialJtag::new(
+        usb_device,
+        Some(flasher_stub::io::usb_serial_jtag::usb_device_handler),
+    );
     usb_serial.listen_rx_packet_recv_interrupt();
-    interrupt::enable(Interrupt::USB_DEVICE, Priority::Priority1).unwrap();
 
-    static mut TRANSPORT: StaticCell<UsbSerialJtag<'static>> = StaticCell::new();
+    static mut TRANSPORT: StaticCell<UsbSerialJtag<'static, Blocking>> = StaticCell::new();
 
     Transport::UsbSerialJtag(unsafe { TRANSPORT.init(usb_serial) })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn transport_uart(uart0: peripherals::UART0, clocks: &Clocks<'_>) -> Transport {
         uart_config,
         None::<TxRxPins<gpio::NoPinType, gpio::NoPinType>>,
         clocks,
-        Some(flasher_stub::io::uart::uart0_hanlder),
+        Some(flasher_stub::io::uart::uart0_handler),
     );
 
     serial.listen_rx_fifo_full();


### PR DESCRIPTION
- Use `XtalClock` as UART source when possible
- Update interrupt bindings

## Testing
I've tried flashing a few targets (C6 and H2) with the generated stubs and they were working fine. 

I've created https://github.com/SergioGasquez/espflash/tree/feat/test-stubs updating all the stubs ~and once https://github.com/esp-rs/espflash/pull/625 is merged, I'll run espflash HIL CI on that branch so we can test all the targets with new stubs.~

Here is the HIL run with the test stubs: https://github.com/esp-rs/espflash/actions/runs/8749962162