### PR TITLE
Add ESP32-C6 and ESP32-H2 support for get_security_info

### DIFF
--- a/ld/esp32c6_rom.x
+++ b/ld/esp32c6_rom.x
@@ -16,3 +16,4 @@ PROVIDE( esp_rom_spiflash_write_encrypted = 0x40000114 );
 PROVIDE( esp_rom_spiflash_write_enable = 0x4000015c );
 PROVIDE( esp_rom_spiflash_erase_area = 0x40000158 );
 PROVIDE( esp_flasher_rom_get_uart = 0x400000b4 );
+PROVIDE( get_security_info_proc = 0x400000bc );

--- a/ld/esp32h2_rom.x
+++ b/ld/esp32h2_rom.x
@@ -16,3 +16,4 @@ PROVIDE( esp_rom_spiflash_write_encrypted = 0x4000010c );
 PROVIDE( esp_rom_spiflash_write_enable = 0x40000154 );
 PROVIDE( esp_rom_spiflash_erase_area = 0x40000150 );
 PROVIDE( esp_flasher_rom_get_uart = 0x400000b4 );
+PROVIDE( get_security_info_proc = 0x400000bc );

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -243,12 +243,6 @@ pub trait EspCommon {
         }
     }
 
-    #[cfg(any(feature = "esp32c6", feature = "esp32h2"))]
-    fn get_security_info(&self) -> Result<[u8; SECURITY_INFO_BYTES], Error> {
-        Err(Error::InvalidCommand)
-    }
-
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32h2")))]
     fn get_security_info(&self) -> Result<[u8; SECURITY_INFO_BYTES], Error> {
         let mut buf: [u8; SECURITY_INFO_BYTES] = [0; SECURITY_INFO_BYTES];
 


### PR DESCRIPTION
esp-flasher-stub v0.2.0 with esptool.py produces the following error for ESP32-C6 and ESP32-H2:

```
A fatal error occurred: Failed to get security info (result was 01C3: Unknown result)
```

This PR solves the above issue.

```
`--> esptool.py --port /dev/ttyUSB0 --chip esp32c6 get_security_info
esptool.py v4.7.0
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C6 (QFN40) (revision v0.0)
Features: WiFi 6, BT 5, IEEE802.15.4
Crystal is 40MHz
MAC: xxxxxxxxxxxxxxx
BASE MAC: xxxxxxxxxxxx
MAC_EXT: xxxxxxxxx
Uploading stub...
Running stub...
Stub running...

Security Information:
=====================
Flags: 0x00000000 (0b0)
Key Purposes: (0, 0, 0, 0, 0, 0, 12)
Chip ID: 13
API Version: 0
Secure Boot: Disabled
Flash Encryption: Disabled
SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT): 0x0
Hard resetting via RTS pin...

`--> esptool.py --port /dev/ttyUSB0 --chip esp32h2 get_security_info
esptool.py v4.7.0
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-H2 (revision v0.2)
Features: BLE, IEEE802.15.4
Crystal is 32MHz
MAC: xxxxxxxxxxxx
BASE MAC: xxxxxxxxxxx
MAC_EXT: xxxxxxx
Uploading stub...
Running stub...
Stub running...

Security Information:
=====================
Flags: 0x00000000 (0b0)
Key Purposes: (0, 0, 0, 0, 0, 0, 12)
Chip ID: 16
API Version: 0
Secure Boot: Disabled
Flash Encryption: Disabled
SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT): 0x0
Hard resetting via RTS pin...
```


Internal reference: ESPTOOL-848