### PR TITLE
Change the ChangeBaudrate command delay to match the esptool stub

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -446,7 +446,7 @@ impl<T: InputIO> Stub<T> {
             ChangeBaudrate => {
                 let baud: ChangeBaudrateCommand = slice_to_struct(payload)?;
                 self.send_response(response);
-                self.target.delay_us(15_000); // Wait for response to be transfered
+                self.target.delay_us(10_000); // Wait for response to be transfered
                 self.target.change_baudrate(baud.old, baud.new);
                 self.target.delay_us(1_000);
                 response_sent = true;


### PR DESCRIPTION
While evaluating the use of `esp-flasher-stub` as a drop-in replacement for stub support in `esp-serial-flasher`, I encountered issues tracing back to [different delay intervals](https://github.com/espressif/esptool/blob/master/flasher_stub/stub_io.c#L310) before changing the UART baudrate.

This changes the delay so that it is in line with the `esptool` stub in order ensure the drop-in nature of `esp-flasher-stub`.

In the future, we might want to consider adding `io.flush()` in order to remove all or almost all delays of this nature.