### PR TITLE
fix(spi_attach): Unattach previously attached SPI flash (ESPTOOL-847)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ codegen-units = 1
 lto           = true
 panic         = "abort"
 debug         = true
+
+[lints.rust]
+unexpected_cfgs = "allow"


### PR DESCRIPTION
Fixed `--spi-connection` not working correctly in esp-stub-flasher (original esptool.py commit: https://github.com/espressif/esptool/commit/afaa7d27536e8050d0ede98e238da966ae649e53)

   - Stub flasher calls `spi_flash_attach` automatically during boot-up, while ROM does this only when `SPI_ATTACH` command is sent by esptool. This means, that stub flasher essentially tries to attach a flash chip twice if `--spi-connection` is used.
   - It is needed to "unattach" the flash chip before attaching another one. This is now done by reconfiguring the SPI pins in the IO MUX back to function as standard GPIOs.
   - This fixes the failing `test_short_flash_to_external_stub` in esptool test suite.