### PR TITLE
Fix the CI badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # esp-flasher-stub
 
-[![GitHub Workflow Status](https://github.com/esp-rs/esp-println/actions/workflows/ci.yml/badge.svg)](https://github.com/esp-rs/esp-println/actions/workflows/ci.yml)
+[![GitHub Workflow Status](https://github.com/esp-rs/esp-flasher-stub/actions/workflows/ci.yml/badge.svg)](https://github.com/esp-rs/esp-flasher-stub/actions/workflows/ci.yml)
 ![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&labelColor=1C2C2E&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 


### PR DESCRIPTION
This has been pointing to the wrong repository this whole time