### PR TITLE
change(legacy_stub): Update information about the legacy stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&labelColor=1C2C2E&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Rust implementation of flasher stub located in [esptool](https://github.com/espressif/esptool/).
+Rust implementation of the [esptool flasher stub](https://github.com/espressif/esptool-legacy-flasher-stub/).
 
 Supports the ESP32, ESP32-C2/C3/C6, ESP32-H2, and ESP32-S2/S3. Currently, `UART` and `USB Serial JTAG` are the supported transport modes, and support for other modes is planned.
 
@@ -64,9 +64,10 @@ In order to run `test_esptool.py` follow steps below:
   ```
 - Copy the stub JSON files into `esptool` installation. You can use the following one-liner:
   ```bash
-  for n in esp*.json; do cp $n $ESPTOOL_PATH/esptool/targets/stub_flasher/stub_flasher_${n#esp}; done
+  for n in esp*.json; do cp $n $ESPTOOL_PATH/esptool/targets/stub_flasher/2/$n; done
   ```
   where `ESPTOOL_PATH` is set to the location where you have cloned `esptool`.
+- Set `ESPTOOL_STUB_VERSION` environment variable to `2`.
 - Run tests
   ```bash
   cd $ESPTOOL_PATH/test

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -126,7 +126,7 @@ impl<T: InputIO> Stub<T> {
     }
 
     fn process_begin(&mut self, cmd: &BeginCommand) -> Result<(), Error> {
-        // Align erase addreess to sector boundady.
+        // Align erase address to sector boundary.
         self.erase_addr = cmd.offset & FLASH_SECTOR_MASK;
         self.write_addr = cmd.offset;
         self.end_addr = cmd.offset + cmd.total_size;

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -17,7 +17,7 @@ struct RomSpiFlashChip {
 
 // ROM SPIFLASH functions can be found here:
 // https://github.com/espressif/esp-idf/tree/master/components/esp_rom or
-// https://github.com/espressif/esptool/tree/master/flasher_stub/ld
+// https://github.com/espressif/esptool-legacy-flasher-stub/tree/master/flasher_stub/ld
 #[allow(unused)]
 extern "C" {
     fn esp_rom_spiflash_erase_chip() -> i32;


### PR DESCRIPTION
The legacy flasher stub is now in its own repo (https://github.com/espressif/esptool-legacy-flasher-stub) and both sets of stubs are used in esptool.

I have updated the information and commands to reflect these changes.