### PR TITLE
fix: Fix the ESP32-S2 security info response size

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -50,7 +50,10 @@ extern "C" {
     fn spi_read_status_high(status: *const u32) -> u32;
 }
 
+#[cfg(not(feature = "esp32s2"))]
 const SECURITY_INFO_BYTES: usize = 20;
+#[cfg(feature = "esp32s2")]
+const SECURITY_INFO_BYTES: usize = 12;
 
 pub const FLASH_SECTOR_SIZE: u32 = 4096;
 pub const FLASH_BLOCK_SIZE: u32 = 65536;


### PR DESCRIPTION
The ESP32-S2 ROM `GET_SECURITY_INFO` response does not contain `chip_id` and `api_version` fields. 
Currently, the flasher stub just returns 0 and 0 for these, however chip_id 0 is reserved for the ESP32.
This makes the stub behavior in line with the ROM.

Since this is a single-chip workaround, `cfg` was chosen instead of creating new traits or using a generic, however that can be remedied in the future if new chips come out with different response sizes.

Closes https://github.com/esp-rs/esp-flasher-stub/issues/65